### PR TITLE
refactor(region): add a constraint for size ghost if ref is null ptr

### DIFF
--- a/include/crab/domains/region/ghost_variable_manager.hpp
+++ b/include/crab/domains/region/ghost_variable_manager.hpp
@@ -149,13 +149,13 @@ public:
     }
   }
 
-  void forget(const variable_t &var, GhostDomain &val) {
+  void forget(const variable_t &var, GhostDomain &val) const {
     if (boost::optional<ghost_variables_t> gvars = get(var)) {
       (*gvars).forget(val);
     }
   }
 
-  void project(const variable_vector_t &vars, GhostDomain &val) {
+  void project(const variable_vector_t &vars, GhostDomain &val) const {
     ghost_variable_vector_t gvars_vec;
     for (auto const &v : vars) {
       if (boost::optional<ghost_variables_t> gvars = get(v)) {
@@ -213,6 +213,10 @@ public:
 	if (ghost_vars.has_offset_and_size()) {
 	  return ghost_vars.get_offset_and_size().get_offset();
 	}
+      } else { // size
+        if (ghost_vars.has_offset_and_size()) {
+          return ghost_vars.get_offset_and_size().get_size();
+        }
       }
       return boost::none;
     };
@@ -226,7 +230,9 @@ public:
         assert(ref_cst.lhs().get_type().is_reference());
         ghost_variable_t x = get_or_insert(ref_cst.lhs()).get_var();
         if (ref_cst.is_equality()) {
-          return ghost_linear_constraint_t(x == number_t(0));
+          boost::optional<ghost_variable_t> sp_x =
+              get_ghost_var(ref_cst.lhs(), kind);
+          return ghost_linear_constraint_t(*sp_x == number_t(0));
         } else if (ref_cst.is_disequality()) {
           return ghost_linear_constraint_t(x != number_t(0));
         } else if (ref_cst.is_less_or_equal_than()) {
@@ -776,7 +782,9 @@ public:
         assert(ref_cst.lhs().get_type().is_reference());
         ghost_variable_t x = get_or_insert(ref_cst.lhs()).get_var();
         if (ref_cst.is_equality()) {
-          return ghost_linear_constraint_t(x == number_t(0));
+          boost::optional<ghost_variable_t> sp_x =
+              get_ghost_var(ref_cst.lhs(), kind);
+          return ghost_linear_constraint_t(*sp_x == number_t(0));
         } else if (ref_cst.is_disequality()) {
           return ghost_linear_constraint_t(x != number_t(0));
         } else if (ref_cst.is_less_or_equal_than()) {

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -1769,8 +1769,14 @@ public:
 	if (!m_is_bottom) {
 	  auto offset_lin_csts = convert_ref_cst_to_linear_cst(ref_cst, ghost_variable_kind::OFFSET);
 	  m_base_dom += offset_lin_csts;
-	  m_is_bottom = m_base_dom.is_bottom();
-	}
+          if (ref_cst.is_unary() && ref_cst.is_equality()) {
+            // a special case for p == NULL: add a constraint for p.size == 0
+            auto size_lin_csts = convert_ref_cst_to_linear_cst(
+                ref_cst, ghost_variable_kind::SIZE);
+            m_base_dom += size_lin_csts;
+          }
+          m_is_bottom = m_base_dom.is_bottom();
+        }
     }
     CRAB_LOG("region",
              crab::outs() << "ref_assume(" << ref_cst << ")" << *this << "\n";);


### PR DESCRIPTION
We can also improve the precisons if a given reference constraints is `p == NULL`. 
For instance,
```c
int sz = int_nd();
__CRAB_assume(sz >= 0);
__CRAB_assume(sz < 10);
uint8_t *ptr = (sz == 0) ? NULL : malloc(sizeof(uint8_t) * sz);
```
We should expect the post invariants (by **zones**) for `ptr` is:
```
sz -> [0, 9] && ptr.address -> [0, +oo]  && sz <= ptr.address + 8 && ptr.offset == 0 && ptr.size == sz
```
Or we can do better if we use the **polyhedra** domain:
```
sz == ptr.size && -sz <= 0 && sz <= 9 && sz-9*ptr.address <= 0; ; ptr.offset == 0
```