### PR TITLE
Domain: variable packing improvement

### DIFF
--- a/include/crab/domains/numerical_packing.hpp
+++ b/include/crab/domains/numerical_packing.hpp
@@ -514,7 +514,13 @@ public:
   }
 
   void expand(const variable_t &var, const variable_t &new_var) override {
-    CRAB_WARN(domain_name(), "::expand not implemented");    
+    if (!is_bottom()) {
+      m_packs.forget(new_var);
+      variable_vector_t vars{var, new_var};
+      if (std::shared_ptr<base_domain_t> absval = merge(vars)) {
+        absval->expand(var, new_var);
+      }
+    }
   }
 
   void normalize() override {}

--- a/include/crab/domains/region/ghost_variables.hpp
+++ b/include/crab/domains/region/ghost_variables.hpp
@@ -89,8 +89,11 @@ public:
       dom.assign(m_offset, number_t(0));
       if (size.is_constant()) {
         dom.assign(m_size, size.get_constant());
+        dom.intrinsic("var_packing_merge", {m_offset, m_size}, {});
       } else {
         dom.assign(m_size, size.get_variable());
+        dom.intrinsic("var_packing_merge",
+                      {m_offset, m_size, size.get_variable()}, {});
       }
     }
 


### PR DESCRIPTION
- Add `expand` implementation
- Add an intrinsic `packing_merge` to pack variables manually.
- Add `packing_merge` calls for initializing `offset` and `size` ghost variables.