### PR TITLE
Add a shared container-printing facility (crab::seq / crab::kv / crab::opt)

### DIFF
--- a/include/crab/analysis/dataflow/assertion_crawler.hpp
+++ b/include/crab/analysis/dataflow/assertion_crawler.hpp
@@ -579,9 +579,8 @@ public:
 	  if (it != m_cdg.end()) {
 	    auto const &children = it->second;
             CRAB_LOG("assertion-crawler-step-control",
-                     crab::outs()
-                         << crab::seq(children, crab::print::fmt_debug())
-                         << " control-dependent on " << pred << "\n";);
+                     crab::outs() << print::seq(children, print::fmt_debug())
+                                  << " control-dependent on " << pred << "\n";);
             add_control_deps op(m_cdg, children, s.get_live());
 	    transform_sol_t cf;
 	    m_sol.get_first() = std::move(cf.apply_on_key_and_value(m_sol.get_first(), op));
@@ -731,10 +730,9 @@ public:
                               << callee_summary.get_second() << "\n";
                  crab::outs()
                  << "\tCallee input variables: "
-                 << crab::seq(callee_inputs, crab::print::fmt_debug())
+                 << print::seq(callee_inputs, print::fmt_debug())
                  << "\n\tCallee output variables: "
-                 << crab::seq(callee_outputs, crab::print::fmt_debug())
-                 << "\n";);
+                 << print::seq(callee_outputs, print::fmt_debug()) << "\n";);
 
         // -- Update assertion map domain at the caller
 	assert_map_domain_t amd(m_sol.get_first());

--- a/include/crab/analysis/dataflow/assertion_crawler.hpp
+++ b/include/crab/analysis/dataflow/assertion_crawler.hpp
@@ -6,6 +6,7 @@
 #include <crab/domains/discrete_domains.hpp>
 #include <crab/fixpoint/killgen_fixpoint_iterator.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 #include <crab/types/indexable.hpp>
 
@@ -577,12 +578,11 @@ public:
 	  auto it = m_cdg.find(pred);
 	  if (it != m_cdg.end()) {
 	    auto const &children = it->second;
-	    CRAB_LOG("assertion-crawler-step-control", crab::outs() << "{";
-		     for (auto &c : children) {
-		       crab::outs() << c << ";";
-		     }
-		     crab::outs() << "} control-dependent on " << pred << "\n";);
-	    add_control_deps op(m_cdg, children, s.get_live());
+            CRAB_LOG("assertion-crawler-step-control",
+                     crab::outs()
+                         << crab::seq(children, crab::print::fmt_debug())
+                         << " control-dependent on " << pred << "\n";);
+            add_control_deps op(m_cdg, children, s.get_live());
 	    transform_sol_t cf;
 	    m_sol.get_first() = std::move(cf.apply_on_key_and_value(m_sol.get_first(), op));
 	    CRAB_LOG("assertion-crawler-step-control",
@@ -726,20 +726,17 @@ public:
 	const std::vector<variable_t> &callee_outputs = callee_summary_info.get_outputs();	
 	auto &callee_summary = callee_summary_info.get_summary();
 
-	CRAB_LOG("assertion-crawler-step-cs",
-		 crab::outs() << "\tSummary at the callee: "
-		 << callee_summary.get_second() << "\n";
-		 crab::outs() << "\tCallee input variables: {";
-		 for (auto const& v: callee_inputs) {
-		   crab::outs() << v << ";";
-		 }
-		 crab::outs() << "}\n\tCallee output variables: {";
-		 for (auto const& v: callee_outputs) {
-		   crab::outs() << v << ";";
-		 }
-		 crab::outs() << "}\n";);
+        CRAB_LOG("assertion-crawler-step-cs",
+                 crab::outs() << "\tSummary at the callee: "
+                              << callee_summary.get_second() << "\n";
+                 crab::outs()
+                 << "\tCallee input variables: "
+                 << crab::seq(callee_inputs, crab::print::fmt_debug())
+                 << "\n\tCallee output variables: "
+                 << crab::seq(callee_outputs, crab::print::fmt_debug())
+                 << "\n";);
 
-	// -- Update assertion map domain at the caller
+        // -- Update assertion map domain at the caller
 	assert_map_domain_t amd(m_sol.get_first());
 	rename(amd, callsite_outputs, callee_outputs);
 	apply_summary(amd, callee_summary.get_second());

--- a/include/crab/analysis/fwd_bwd_analyzer.hpp
+++ b/include/crab/analysis/fwd_bwd_analyzer.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <crab/analysis/abs_transformer.hpp>
+#include <crab/analysis/bwd_np_analyzer.hpp>
 #include <crab/analysis/dataflow/liveness.hpp>
 #include <crab/analysis/fwd_analyzer.hpp>
-#include <crab/analysis/bwd_np_analyzer.hpp>
 #include <crab/analysis/fwd_bwd_params.hpp>
 #include <crab/analysis/graphs/dominance.hpp>
+#include <crab/support/print.hpp>
 
 #include <boost/range/iterator_range.hpp>
 #include <algorithm>
@@ -342,18 +343,17 @@ public:
         }
       }
 
-      CRAB_LOG("backward-dom-tree", crab::outs() << "Computed dominance tree:\n";
-               for (auto &kv
-                    : idom_tree) {
-                 crab::outs()
-                     << "\t"
-                     << basic_block_traits<basic_block_t>::to_string(kv.first)
-                     << " dominates={";
-                 for (auto d : kv.second) {
-                   crab::outs() << d << ";";
-                 }
-                 crab::outs() << "}\n";
-               });
+      CRAB_LOG(
+          "backward-dom-tree", crab::outs() << "Computed dominance tree:\n";
+          for (auto &kv
+               : idom_tree) {
+            crab::outs() << "\t"
+                         << basic_block_traits<basic_block_t>::to_string(
+                                kv.first)
+                         << " dominates="
+                         << crab::seq(kv.second, crab::print::fmt_debug())
+                         << "\n";
+          });
     }
     assumption_map_t refined_assumptions(assumptions.begin(), assumptions.end());
 

--- a/include/crab/analysis/fwd_bwd_analyzer.hpp
+++ b/include/crab/analysis/fwd_bwd_analyzer.hpp
@@ -351,8 +351,7 @@ public:
                          << basic_block_traits<basic_block_t>::to_string(
                                 kv.first)
                          << " dominates="
-                         << crab::seq(kv.second, crab::print::fmt_debug())
-                         << "\n";
+                         << print::seq(kv.second, print::fmt_debug()) << "\n";
           });
     }
     assumption_map_t refined_assumptions(assumptions.begin(), assumptions.end());

--- a/include/crab/analysis/graphs/cdg.hpp
+++ b/include/crab/analysis/graphs/cdg.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <crab/analysis/graphs/dominance.hpp>
+#include <crab/support/print.hpp>
 //#include <crab/cfg/basic_block_traits.hpp>
 /*
 
@@ -30,18 +31,20 @@ void control_dep_graph(G g, VectorMap &cdg) {
     }
   }
 
-  CRAB_LOG("cdg", crab::outs() << "Control-dependence graph \n"; for (auto &kv
-                                                                      : cdg) {
-    crab::outs() << "{";
-    for (auto v : kv.second) {
-      crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(v)
-                   << ";";
-    }
-    crab::outs() << "} "
-                 << " control-dependent on ";
-    crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(kv.first)
-                 << "\n";
-  });
+  CRAB_LOG(
+      "cdg", crab::outs() << "Control-dependence graph \n"; for (auto &kv
+                                                                 : cdg) {
+        crab::print::print_range_with(
+            crab::outs(), kv.second,
+            [](crab::crab_os &o, const auto &v) {
+              o << crab::basic_block_traits<basic_block_t>::to_string(v);
+            },
+            crab::print::fmt_debug());
+        crab::outs() << "  control-dependent on "
+                     << crab::basic_block_traits<basic_block_t>::to_string(
+                            kv.first)
+                     << "\n";
+      });
 }
 
 } // namespace graph_algo

--- a/include/crab/analysis/graphs/cdg.hpp
+++ b/include/crab/analysis/graphs/cdg.hpp
@@ -34,12 +34,12 @@ void control_dep_graph(G g, VectorMap &cdg) {
   CRAB_LOG(
       "cdg", crab::outs() << "Control-dependence graph \n"; for (auto &kv
                                                                  : cdg) {
-        crab::print::print_range_with(
+        print::print_range_with(
             crab::outs(), kv.second,
             [](crab::crab_os &o, const auto &v) {
               o << crab::basic_block_traits<basic_block_t>::to_string(v);
             },
-            crab::print::fmt_debug());
+            print::fmt_debug());
         crab::outs() << "  control-dependent on "
                      << crab::basic_block_traits<basic_block_t>::to_string(
                             kv.first)

--- a/include/crab/analysis/graphs/dominance.hpp
+++ b/include/crab/analysis/graphs/dominance.hpp
@@ -165,12 +165,12 @@ void dominance(G g, typename G::node_t entry, VectorMap &df) {
         crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(
                             kv.first)
                      << "=";
-        crab::print::print_range_with(
+        print::print_range_with(
             crab::outs(), kv.second,
             [](crab::crab_os &o, const auto &v) {
               o << crab::basic_block_traits<basic_block_t>::to_string(v);
             },
-            crab::print::fmt_debug());
+            print::fmt_debug());
         crab::outs() << "\n";
       });
 }

--- a/include/crab/analysis/graphs/dominance.hpp
+++ b/include/crab/analysis/graphs/dominance.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 //#include <crab/cfg/basic_block_traits.hpp>
 
@@ -158,16 +159,20 @@ void dominance(G g, typename G::node_t entry, VectorMap &df) {
   } // end outer for
   //crab::CrabStats::stop("Dominance Frontier");
 
-  CRAB_LOG("dominance", for (auto &kv
-                             : df) {
-    crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(kv.first)
-                 << "={";
-    for (auto v : kv.second) {
-      crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(v)
-                   << ";";
-    }
-    crab::outs() << "}\n";
-  });
+  CRAB_LOG(
+      "dominance", for (auto &kv
+                        : df) {
+        crab::outs() << crab::basic_block_traits<basic_block_t>::to_string(
+                            kv.first)
+                     << "=";
+        crab::print::print_range_with(
+            crab::outs(), kv.second,
+            [](crab::crab_os &o, const auto &v) {
+              o << crab::basic_block_traits<basic_block_t>::to_string(v);
+            },
+            crab::print::fmt_debug());
+        crab::outs() << "\n";
+      });
 }
 
 } // namespace graph_algo_impl

--- a/include/crab/analysis/inter/top_down_inter_analyzer.hpp
+++ b/include/crab/analysis/inter/top_down_inter_analyzer.hpp
@@ -506,7 +506,7 @@ private:
       boost::optional<wto_cg_nesting_t> res = it->second->nesting(node);
       CRAB_LOG("inter-callgraph-wto",
                crab::outs() << "NESTING(" << node
-                            << ")=" << crab::opt(res, "[]") << "\n";);
+                            << ")=" << print::opt(res, "[]") << "\n";);
       return res;
     } else {
       CRAB_ERROR("Not callgraph wto found for entry ",
@@ -1586,10 +1586,10 @@ public:
     }
 
     CRAB_LOG("inter", crab::outs() << "Widening points=";
-             crab::print::print_range_with(
+             print::print_range_with(
                  crab::outs(), widening_set,
                  [](crab_os &o, const auto &cg_node) { o << cg_node.name(); },
-                 crab::print::fmt_debug());
+                 print::fmt_debug());
              crab::outs() << "\n";);
     CRAB_VERBOSE_IF(1, get_msg_stream() << "Done.\n";);
 

--- a/include/crab/analysis/inter/top_down_inter_analyzer.hpp
+++ b/include/crab/analysis/inter/top_down_inter_analyzer.hpp
@@ -26,11 +26,12 @@
 #include <crab/analysis/inter/inter_analyzer_api.hpp>
 #include <crab/analysis/inter/inter_params.hpp>
 #include <crab/cg/cg_bgl.hpp> // for wto of callgraphs
-#include <crab/fixpoint/wto.hpp>
-#include <crab/fixpoint/fixpoint_params.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
 #include <crab/domains/inter_abstract_operations_callsite_info.hpp>
+#include <crab/fixpoint/fixpoint_params.hpp>
+#include <crab/fixpoint/wto.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <crab/checkers/assertion.hpp>
@@ -504,13 +505,8 @@ private:
     if (it != m_wto_cg_map.end()) {
       boost::optional<wto_cg_nesting_t> res = it->second->nesting(node);
       CRAB_LOG("inter-callgraph-wto",
-	       crab::outs() << "NESTING(" << node  << ")=";
-	       if (res) {
-		 crab::outs() << *res;
-	       } else {
-		 crab::outs() << "[]";
-	       }
-	       crab::outs() << "\n";);
+               crab::outs() << "NESTING(" << node
+                            << ")=" << crab::opt(res, "[]") << "\n";);
       return res;
     } else {
       CRAB_ERROR("Not callgraph wto found for entry ",
@@ -1589,11 +1585,12 @@ public:
       wto_cg_map[entry] = std::move(wto_cg);
     }
 
-    CRAB_LOG(
-        "inter", crab::outs() << "Widening points={"; for (auto &cg_node
-                                                           : widening_set) {
-          crab::outs() << cg_node.name() << ";";
-        } crab::outs() << "}\n";);
+    CRAB_LOG("inter", crab::outs() << "Widening points=";
+             crab::print::print_range_with(
+                 crab::outs(), widening_set,
+                 [](crab_os &o, const auto &cg_node) { o << cg_node.name(); },
+                 crab::print::fmt_debug());
+             crab::outs() << "\n";);
     CRAB_VERBOSE_IF(1, get_msg_stream() << "Done.\n";);
 
     if (entries.empty()) {

--- a/include/crab/domains/apron_domains.hpp
+++ b/include/crab/domains/apron_domains.hpp
@@ -4,10 +4,11 @@
 
 #include <crab/domains/abstract_domain.hpp>
 #include <crab/domains/abstract_domain_specialized_traits.hpp>
-#include <crab/domains/intervals.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/intervals.hpp>
 #include <crab/numbers/bignums.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <algorithm>
@@ -1658,13 +1659,12 @@ public:
     if (is_top() || is_bottom())
       return;
 
-    CRAB_LOG("apron", crab::outs() << "Renaming {"; for (auto v
-                                                         : from) crab::outs()
-                                                    << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("apron", crab::outs()
+                          << "Renaming "
+                          << crab::seq(from, crab::print::fmt_debug())
+                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << ":\n"
+                          << *this << "\n";);
 
     for (unsigned i = 0, sz = from.size(); i < sz; ++i) {
       variable_t v = from[i];

--- a/include/crab/domains/apron_domains.hpp
+++ b/include/crab/domains/apron_domains.hpp
@@ -1660,9 +1660,8 @@ public:
       return;
 
     CRAB_LOG("apron", crab::outs()
-                          << "Renaming "
-                          << crab::seq(from, crab::print::fmt_debug())
-                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << "Renaming " << print::seq(from, print::fmt_debug())
+                          << " with " << print::seq(to, print::fmt_debug())
                           << ":\n"
                           << *this << "\n";);
 

--- a/include/crab/domains/array_adaptive.hpp
+++ b/include/crab/domains/array_adaptive.hpp
@@ -2618,8 +2618,7 @@ public:
           CRAB_LOG("array-adaptive",
                    crab::outs()
                        << "Killed cells: "
-                       << crab::seq(cells, crab::print::fmt_set_tight())
-                       << "\n";);
+                       << print::seq(cells, print::fmt_set_tight()) << "\n";);
 
           kill_cells(a, cells, offset_map);
         }
@@ -2720,8 +2719,7 @@ public:
                std::vector<variable_t> array_variables = get_array_variables();
                crab::outs()
                << "array variables="
-               << crab::seq(array_variables, crab::print::fmt_debug())
-               << "\n";);
+               << print::seq(array_variables, print::fmt_debug()) << "\n";);
 
       for (auto &kv : renmap) {
         CRAB_LOG("array-adaptive-array-assign",

--- a/include/crab/domains/array_adaptive.hpp
+++ b/include/crab/domains/array_adaptive.hpp
@@ -48,10 +48,11 @@
 #include <crab/domains/abstract_domain_params.hpp>
 #include <crab/domains/abstract_domain_specialized_traits.hpp>
 #include <crab/domains/array_smashing.hpp>
-#include <crab/domains/interval.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/interval.hpp>
 #include <crab/domains/patricia_trees.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 #include <crab/types/indexable.hpp>
 
@@ -2614,16 +2615,11 @@ public:
           std::vector<cell_t> cells;
           offset_map.get_overlap_cells_symbolic_offset(m_base_dom, symb_lb,
                                                        symb_ub, cells);
-          CRAB_LOG(
-              "array-adaptive", crab::outs() << "Killed cells: {";
-              for (unsigned j = 0; j < cells.size();) {
-                crab::outs() << cells[j];
-                ++j;
-                if (j < cells.size()) {
-                  crab::outs() << ",";
-                }
-              } crab::outs()
-              << "}\n";);
+          CRAB_LOG("array-adaptive",
+                   crab::outs()
+                       << "Killed cells: "
+                       << crab::seq(cells, crab::print::fmt_set_tight())
+                       << "\n";);
 
           kill_cells(a, cells, offset_map);
         }
@@ -2720,12 +2716,12 @@ public:
       m_array_map.set(
           lhs, array_state(false, std::move(elem_sz), std::move(lhs_om)));
 
-      CRAB_LOG(
-          "array-adaptive-array-assign", crab::outs() << "array variables={";
-          std::vector<variable_t> array_variables = get_array_variables();
-          for (unsigned i = 0, e = array_variables.size(); i < e;
-               ++i) { crab::outs() << array_variables[i] << ";"; } crab::outs()
-          << "}\n";);
+      CRAB_LOG("array-adaptive-array-assign",
+               std::vector<variable_t> array_variables = get_array_variables();
+               crab::outs()
+               << "array variables="
+               << crab::seq(array_variables, crab::print::fmt_debug())
+               << "\n";);
 
       for (auto &kv : renmap) {
         CRAB_LOG("array-adaptive-array-assign",

--- a/include/crab/domains/elina_domains.hpp
+++ b/include/crab/domains/elina_domains.hpp
@@ -4,9 +4,10 @@
 
 #include <crab/domains/abstract_domain.hpp>
 #include <crab/domains/abstract_domain_specialized_traits.hpp>
-#include <crab/domains/intervals.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/intervals.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 namespace crab {
@@ -1271,16 +1272,10 @@ public:
 
     remove_dimensions(m_apstate, vector_dims);
     std::swap(m_var_map, res);
-    CRAB_LOG("elina", crab::outs() << "--- "
-                                   << "Forget {";
-             for (variable_t v
-                  : vars) { crab::outs() << v << ";"; }
-             // crab::outs()<< "} Elina dimensions ={";
-             // for(unsigned i=0,e=vector_dims.size();i<e;++i) {
-             // 	 crab::outs() << vector_dims[i] << ";";
-             // }
-             crab::outs()
-             << "}\n";
+    CRAB_LOG("elina", crab::outs()
+                          << "--- "
+                          << "Forget "
+                          << crab::seq(vars, crab::print::fmt_debug()) << "\n";
              crab::outs() << *this << "\n";);
   }
 
@@ -1839,13 +1834,12 @@ public:
     if (is_top() || is_bottom())
       return;
 
-    CRAB_LOG("elina", crab::outs() << "Renaming {"; for (auto v
-                                                         : from) crab::outs()
-                                                    << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("elina", crab::outs()
+                          << "Renaming "
+                          << crab::seq(from, crab::print::fmt_debug())
+                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << ":\n"
+                          << *this << "\n";);
 
     for (unsigned i = 0, sz = from.size(); i < sz; ++i) {
       variable_t v = from[i];

--- a/include/crab/domains/elina_domains.hpp
+++ b/include/crab/domains/elina_domains.hpp
@@ -1274,8 +1274,8 @@ public:
     std::swap(m_var_map, res);
     CRAB_LOG("elina", crab::outs()
                           << "--- "
-                          << "Forget "
-                          << crab::seq(vars, crab::print::fmt_debug()) << "\n";
+                          << "Forget " << print::seq(vars, print::fmt_debug())
+                          << "\n";
              crab::outs() << *this << "\n";);
   }
 
@@ -1835,9 +1835,8 @@ public:
       return;
 
     CRAB_LOG("elina", crab::outs()
-                          << "Renaming "
-                          << crab::seq(from, crab::print::fmt_debug())
-                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << "Renaming " << print::seq(from, print::fmt_debug())
+                          << " with " << print::seq(to, print::fmt_debug())
                           << ":\n"
                           << *this << "\n";);
 

--- a/include/crab/domains/herbrand_domain.hpp
+++ b/include/crab/domains/herbrand_domain.hpp
@@ -1254,9 +1254,9 @@ public:
     }
 
     CRAB_LOG("uf", crab::outs()
-                       << "Renaming "
-                       << crab::seq(from, crab::print::fmt_debug()) << " with "
-                       << crab::seq(to, crab::print::fmt_debug()) << ":\n"
+                       << "Renaming " << print::seq(from, print::fmt_debug())
+                       << " with " << print::seq(to, print::fmt_debug())
+                       << ":\n"
                        << *this << "\n";);
 
     auto error_if_found = [this](const variable_t &v) {

--- a/include/crab/domains/herbrand_domain.hpp
+++ b/include/crab/domains/herbrand_domain.hpp
@@ -24,6 +24,7 @@
 #include <crab/domains/term/term_expr.hpp>
 #include <crab/domains/term/term_operators.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <algorithm>
@@ -1252,15 +1253,11 @@ public:
       return;
     }
 
-    CRAB_LOG(
-        "uf", crab::outs() << "Renaming {"; for (auto v
-                                                 : from) {
-          crab::outs() << v << ";";
-        } crab::outs() << "} with ";
-        for (auto v
-             : to) { crab::outs() << v << ";"; } crab::outs()
-        << "}:\n";
-        crab::outs() << *this << "\n";);
+    CRAB_LOG("uf", crab::outs()
+                       << "Renaming "
+                       << crab::seq(from, crab::print::fmt_debug()) << " with "
+                       << crab::seq(to, crab::print::fmt_debug()) << ":\n"
+                       << *this << "\n";);
 
     auto error_if_found = [this](const variable_t &v) {
       auto it = m_var_map.find(v);

--- a/include/crab/domains/inter_abstract_operations_impl.hpp
+++ b/include/crab/domains/inter_abstract_operations_impl.hpp
@@ -189,8 +189,8 @@ void inter_abstract_operations<Domain, true>::callee_entry(
   callee_at_entry.project(callsite.get_callee_in_params());
   CRAB_LOG("inter-restrict",
            errs() << "Inv at the callee after projecting onto formals: "
-                  << crab::seq(callsite.get_callee_in_params(),
-                               crab::print::fmt_debug().bare())
+                  << print::seq(callsite.get_callee_in_params(),
+                                print::fmt_debug().bare())
                   << "\n"
                   << callee_at_entry << "\n";);
 }
@@ -292,10 +292,10 @@ void inter_abstract_operations<Domain, true>::caller_continuation(
   // 4. Forget callee's parameters
   callee_at_exit.forget(callee_params);
 
-  CRAB_LOG("inter-extend",
-           crab::outs() << "Forgotten all callee parameters "
-                        << crab::seq(callee_params, crab::print::fmt_debug())
-                        << "\n";);
+  CRAB_LOG("inter-extend", crab::outs()
+                               << "Forgotten all callee parameters "
+                               << print::seq(callee_params, print::fmt_debug())
+                               << "\n";);
 
   CRAB_LOG("inter-extend2", crab::outs()
                                 << "Meet caller with callee:\n"

--- a/include/crab/domains/inter_abstract_operations_impl.hpp
+++ b/include/crab/domains/inter_abstract_operations_impl.hpp
@@ -4,6 +4,7 @@
 /**==============================================================**/
 #include <crab/support/debug.hpp>
 #include <crab/support/os.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 #include <crab/types/reference_constraints.hpp>
 #include <crab/types/variable.hpp>
@@ -186,13 +187,12 @@ void inter_abstract_operations<Domain, true>::callee_entry(
 
   // 3. Project onto **input** formal parameters
   callee_at_entry.project(callsite.get_callee_in_params());
-  CRAB_LOG(
-      "inter-restrict",
-      errs() << "Inv at the callee after projecting onto formals: ";
-      for (auto &v
-           : callsite.get_callee_in_params()) { errs() << v << ";"; } errs()
-      << "\n"
-      << callee_at_entry << "\n";);
+  CRAB_LOG("inter-restrict",
+           errs() << "Inv at the callee after projecting onto formals: "
+                  << crab::seq(callsite.get_callee_in_params(),
+                               crab::print::fmt_debug().bare())
+                  << "\n"
+                  << callee_at_entry << "\n";);
 }
 
 template <class Domain>
@@ -292,11 +292,10 @@ void inter_abstract_operations<Domain, true>::caller_continuation(
   // 4. Forget callee's parameters
   callee_at_exit.forget(callee_params);
 
-  CRAB_LOG(
-      "inter-extend", crab::outs() << "Forgotten all callee parameters {";
-      for (auto const &v
-           : callee_params) { crab::outs() << v << ";"; } crab::outs()
-      << "}\n";);
+  CRAB_LOG("inter-extend",
+           crab::outs() << "Forgotten all callee parameters "
+                        << crab::seq(callee_params, crab::print::fmt_debug())
+                        << "\n";);
 
   CRAB_LOG("inter-extend2", crab::outs()
                                 << "Meet caller with callee:\n"

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -3,13 +3,14 @@
 #include <crab/domains/abstract_domain.hpp>
 #include <crab/domains/abstract_domain_params.hpp>
 #include <crab/domains/boolean.hpp>
-#include <crab/domains/interval.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/interval.hpp>
 #include <crab/domains/separate_domains.hpp>
 #include <crab/domains/small_range.hpp>
 #include <crab/domains/types.hpp>
 #include <crab/domains/union_find_domain.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 #include <crab/types/reference_constraints.hpp>
 #include <crab/types/tag.hpp>
@@ -2842,30 +2843,24 @@ public:
 	  }
 	  o << "," << "BaseDom=" << m_base_dom  << ")\n";
 	  return;
-	       );	       
-	  
-      CRAB_LOG(
-	  "region-print-debug",	       
-	  /// This format is understood by Clam debugging scripts such
-	  /// as read_assertions.py.
-	  o << "(" 
-	  << "RgnCounter="
-	  << "{";
-	  for(auto it = m_rgn_env.begin(), et = m_rgn_env.end(); it!=et;) {
-	    o << it->first  << " -> " << it->second.refcount_val();
-	    ++it;
-	    if (it != et) {
-	      o << ";";
-	    }	  
-	  }
-	  o << "}," << "BaseDom=";
-	  
-	  // We ask the ghost manager to print the base domain so that it
-	  // can rename ghost variables to user-friendly names.
-	  m_ghost_var_man.write(o, m_base_dom);
-	  o << ")";
-	  return;
-	       );      
+	       );
+
+      CRAB_LOG("region-print-debug",
+               /// This format is understood by Clam debugging scripts such
+               /// as read_assertions.py.
+               o << "("
+                 << "RgnCounter=";
+               crab::print::print_range_with(
+                   o, m_rgn_env,
+                   [](crab_os &o, const auto &p) {
+                     o << p.first << " -> " << p.second.refcount_val();
+                   },
+                   crab::print::fmt_set().sep(";"));
+               o << ","
+                 << "BaseDom=";
+               // We ask the ghost manager to print the base domain so that it
+               // can rename ghost variables to user-friendly names.
+               m_ghost_var_man.write(o, m_base_dom); o << ")"; return;);
 
       // We ask the ghost manager to print the base domain so that it
       // can rename ghost variables to user-friendly names.

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -2850,12 +2850,12 @@ public:
                /// as read_assertions.py.
                o << "("
                  << "RgnCounter=";
-               crab::print::print_range_with(
+               print::print_range_with(
                    o, m_rgn_env,
                    [](crab_os &o, const auto &p) {
                      o << p.first << " -> " << p.second.refcount_val();
                    },
-                   crab::print::fmt_set().sep(";"));
+                   print::fmt_set().sep(";"));
                o << ","
                  << "BaseDom=";
                // We ask the ghost manager to print the base domain so that it

--- a/include/crab/domains/sparse_dbm.hpp
+++ b/include/crab/domains/sparse_dbm.hpp
@@ -15,9 +15,10 @@
 #include <crab/domains/backward_assign_operations.hpp>
 #include <crab/domains/graphs/graph_config.hpp>
 #include <crab/domains/graphs/graph_ops.hpp>
-#include <crab/domains/interval.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/interval.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <boost/container/flat_map.hpp>
@@ -2073,14 +2074,12 @@ public:
     // renaming vert_map by creating a new vert_map since we are
     // modifying the keys.
     // rev_map is modified in-place since we only modify values.
-    CRAB_LOG("zones-sparse", crab::outs() << "Renaming {";
-             for (auto v
-                  : from) crab::outs()
-             << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("zones-sparse",
+             crab::outs() << "Renaming "
+                          << crab::seq(from, crab::print::fmt_debug())
+                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << ":\n"
+                          << *this << "\n";);
 
     for (unsigned i = 0, sz = from.size(); i < sz; ++i) {
       variable_t v = from[i];

--- a/include/crab/domains/sparse_dbm.hpp
+++ b/include/crab/domains/sparse_dbm.hpp
@@ -2075,9 +2075,8 @@ public:
     // modifying the keys.
     // rev_map is modified in-place since we only modify values.
     CRAB_LOG("zones-sparse",
-             crab::outs() << "Renaming "
-                          << crab::seq(from, crab::print::fmt_debug())
-                          << " with " << crab::seq(to, crab::print::fmt_debug())
+             crab::outs() << "Renaming " << print::seq(from, print::fmt_debug())
+                          << " with " << print::seq(to, print::fmt_debug())
                           << ":\n"
                           << *this << "\n";);
 

--- a/include/crab/domains/split_dbm.hpp
+++ b/include/crab/domains/split_dbm.hpp
@@ -24,9 +24,10 @@
 #include <crab/domains/graphs/graph_config.hpp>
 #include <crab/domains/graphs/graph_ops.hpp>
 #include <crab/domains/graphs/graph_views.hpp>
-#include <crab/domains/interval.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/interval.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <boost/optional.hpp>
@@ -2735,14 +2736,12 @@ public:
     if (is_top() || is_bottom())
       return;
 
-    CRAB_LOG("zones-split", crab::outs() << "Renaming {";
-             for (auto v
-                  : from) crab::outs()
-             << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("zones-split",
+             crab::outs() << "Renaming "
+                          << crab::seq(from, crab::print::fmt_debug())
+                          << " with " << crab::seq(to, crab::print::fmt_debug())
+                          << ":\n"
+                          << *this << "\n";);
 
     for (unsigned i = 0, sz = from.size(); i < sz; ++i) {
       variable_t v = from[i];

--- a/include/crab/domains/split_dbm.hpp
+++ b/include/crab/domains/split_dbm.hpp
@@ -2737,9 +2737,8 @@ public:
       return;
 
     CRAB_LOG("zones-split",
-             crab::outs() << "Renaming "
-                          << crab::seq(from, crab::print::fmt_debug())
-                          << " with " << crab::seq(to, crab::print::fmt_debug())
+             crab::outs() << "Renaming " << print::seq(from, print::fmt_debug())
+                          << " with " << print::seq(to, print::fmt_debug())
                           << ":\n"
                           << *this << "\n";);
 

--- a/include/crab/domains/split_oct.hpp
+++ b/include/crab/domains/split_oct.hpp
@@ -44,10 +44,11 @@
 #include <crab/domains/graphs/graph_config.hpp>
 #include <crab/domains/graphs/graph_ops.hpp>
 #include <crab/domains/graphs/graph_views.hpp>
+#include <crab/domains/inter_abstract_operations.hpp>
 #include <crab/domains/interval.hpp>
 #include <crab/numbers/bignums.hpp>
-#include <crab/domains/inter_abstract_operations.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <boost/optional.hpp>
@@ -2275,25 +2276,21 @@ public:
 	    }
 	  }
 
-	  CRAB_LOG("octagon-join",
-		   crab::outs() << "lb_right={";
-		   for (vert_id s : lb_right) {
-		     crab::outs() << s << ";";
-		   } crab::outs() << "}\n";
-		   crab::outs() << "lb_left={";
-		   for (vert_id s : lb_left) {
-		     crab::outs() << s << ";";
-		   } crab::outs() << "}\n";
-		   crab::outs() << "ub_right={";
-		   for (vert_id s : ub_right) {
-		     crab::outs() << s << ";";
-		   } crab::outs() << "}\n";
-		   crab::outs() << "ub_left={";
-		   for (vert_id s : ub_left) {
-		     crab::outs() << s << ";";
-		   } crab::outs() << "}\n";);
-	  
-	  Wt_min min_op;
+          CRAB_LOG("octagon-join",
+                   crab::outs()
+                       << "lb_right="
+                       << crab::seq(lb_right, crab::print::fmt_debug()) << "\n";
+                   crab::outs()
+                   << "lb_left=" << crab::seq(lb_left, crab::print::fmt_debug())
+                   << "\n";
+                   crab::outs()
+                   << "ub_right="
+                   << crab::seq(ub_right, crab::print::fmt_debug()) << "\n";
+                   crab::outs()
+                   << "ub_left=" << crab::seq(ub_left, crab::print::fmt_debug())
+                   << "\n";);
+
+          Wt_min min_op;
 	  for (vert_id s : lb_left) {
 	    Wt dx_s = gx.edge_val(s, s + 1) / (Wt)2;
 	    Wt dy_s = gy.edge_val(s, s + 1) / (Wt)2;
@@ -2500,16 +2497,18 @@ public:
 
 	  // Now perform the widening
 	  graph_t widen_g(split_widen(gx, gy, widen_unstable));
-	  
-	  CRAB_LOG("octagon-widening", crab::outs()
-		   << "Unstable list after point-wise widening{";
-          for (vert_id v : widen_unstable) {
-		 
-            crab::outs() << *out_revmap[v] << ((v % 2 == 0) ? "+" : "-") << ";";
-          } crab::outs()
-          << "}\n");
 
-	  split_oct_domain_t res(std::move(out_vmap), std::move(out_revmap),
+          CRAB_LOG("octagon-widening",
+                   crab::outs() << "Unstable list after point-wise widening";
+                   crab::print::print_range_with(
+                       crab::outs(), widen_unstable,
+                       [&out_revmap](crab_os &o, const auto &v) {
+                         o << *out_revmap[v] << ((v % 2 == 0) ? "+" : "-");
+                       },
+                       crab::print::fmt_debug());
+                   crab::outs() << "\n";);
+
+          split_oct_domain_t res(std::move(out_vmap), std::move(out_revmap),
 				 std::move(widen_g), std::move(widen_pot),
 				 std::move(widen_unstable));
 	  
@@ -2960,15 +2959,15 @@ public:
       return;
     }
 
-    CRAB_LOG(
-        "octagon-normalize", crab::outs()
-                                 << "Normalization...\nUnstable list {";
-        for (vert_id v
-             : m_unstable) {
-          crab::outs() << *m_rev_vert_map[v] << ((v % 2 == 0) ? "+" : "-")
-                       << ";";
-        } crab::outs()
-        << "}\n";);
+    CRAB_LOG("octagon-normalize", crab::outs()
+                                      << "Normalization...\nUnstable list ";
+             crab::print::print_range_with(
+                 crab::outs(), m_unstable,
+                 [this](crab_os &o, const auto &v) {
+                   o << *m_rev_vert_map[v] << ((v % 2 == 0) ? "+" : "-");
+                 },
+                 crab::print::fmt_debug());
+             crab::outs() << "\n";);
 
     edge_vector delta;
     split_octagons_impl::SplitOctGraph<graph_t> g_oct(m_graph);
@@ -2983,18 +2982,19 @@ public:
       GrOps::close_johnson(g_oct, m_potential, delta);
     }
 
-    CRAB_LOG(
-        "octagon-normalize", crab::outs() << "Edges after close_after_widen {";
-        for (auto edge
-             : delta) {
-          vert_id src = edge.first.first;
-          vert_id dst = edge.first.second;
-          Wt w = edge.second;
-          crab::outs() << *m_rev_vert_map[src] << ((src % 2 == 0) ? "+" : "-")
-                       << "-->" << *m_rev_vert_map[dst]
-                       << ((dst % 2 == 0) ? "+" : "-") << " w=" << w << ";";
-        } crab::outs()
-        << "}\n";);
+    CRAB_LOG("octagon-normalize", crab::outs()
+                                      << "Edges after close_after_widen ";
+             crab::print::print_range_with(
+                 crab::outs(), delta,
+                 [this](crab_os &o, const auto &edge) {
+                   vert_id src = edge.first.first;
+                   vert_id dst = edge.first.second;
+                   o << *m_rev_vert_map[src] << ((src % 2 == 0) ? "+" : "-")
+                     << "-->" << *m_rev_vert_map[dst]
+                     << ((dst % 2 == 0) ? "+" : "-") << " w=" << edge.second;
+                 },
+                 crab::print::fmt_debug());
+             crab::outs() << "\n";);
 
     // JN: we should be fine calling GrOps::apply_delta
     update_delta(m_graph, delta);
@@ -3557,13 +3557,12 @@ public:
 
     normalize();
 
-    CRAB_LOG("octagon", crab::outs() << "Replacing {"; for (auto v
-                                                            : from) crab::outs()
-                                                       << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("octagon", crab::outs()
+                            << "Replacing "
+                            << crab::seq(from, crab::print::fmt_debug())
+                            << " with "
+                            << crab::seq(to, crab::print::fmt_debug()) << ":\n"
+                            << *this << "\n";);
 
     vert_map_t new_vert_map;
     for (auto kv : m_vert_map) {

--- a/include/crab/domains/split_oct.hpp
+++ b/include/crab/domains/split_oct.hpp
@@ -2276,19 +2276,16 @@ public:
 	    }
 	  }
 
-          CRAB_LOG("octagon-join",
-                   crab::outs()
-                       << "lb_right="
-                       << crab::seq(lb_right, crab::print::fmt_debug()) << "\n";
-                   crab::outs()
-                   << "lb_left=" << crab::seq(lb_left, crab::print::fmt_debug())
-                   << "\n";
-                   crab::outs()
-                   << "ub_right="
-                   << crab::seq(ub_right, crab::print::fmt_debug()) << "\n";
-                   crab::outs()
-                   << "ub_left=" << crab::seq(ub_left, crab::print::fmt_debug())
-                   << "\n";);
+          CRAB_LOG(
+              "octagon-join",
+              crab::outs() << "lb_right="
+                           << print::seq(lb_right, print::fmt_debug()) << "\n";
+              crab::outs() << "lb_left="
+                           << print::seq(lb_left, print::fmt_debug()) << "\n";
+              crab::outs() << "ub_right="
+                           << print::seq(ub_right, print::fmt_debug()) << "\n";
+              crab::outs() << "ub_left="
+                           << print::seq(ub_left, print::fmt_debug()) << "\n";);
 
           Wt_min min_op;
 	  for (vert_id s : lb_left) {
@@ -2500,12 +2497,12 @@ public:
 
           CRAB_LOG("octagon-widening",
                    crab::outs() << "Unstable list after point-wise widening";
-                   crab::print::print_range_with(
+                   print::print_range_with(
                        crab::outs(), widen_unstable,
                        [&out_revmap](crab_os &o, const auto &v) {
                          o << *out_revmap[v] << ((v % 2 == 0) ? "+" : "-");
                        },
-                       crab::print::fmt_debug());
+                       print::fmt_debug());
                    crab::outs() << "\n";);
 
           split_oct_domain_t res(std::move(out_vmap), std::move(out_revmap),
@@ -2961,12 +2958,12 @@ public:
 
     CRAB_LOG("octagon-normalize", crab::outs()
                                       << "Normalization...\nUnstable list ";
-             crab::print::print_range_with(
+             print::print_range_with(
                  crab::outs(), m_unstable,
                  [this](crab_os &o, const auto &v) {
                    o << *m_rev_vert_map[v] << ((v % 2 == 0) ? "+" : "-");
                  },
-                 crab::print::fmt_debug());
+                 print::fmt_debug());
              crab::outs() << "\n";);
 
     edge_vector delta;
@@ -2984,7 +2981,7 @@ public:
 
     CRAB_LOG("octagon-normalize", crab::outs()
                                       << "Edges after close_after_widen ";
-             crab::print::print_range_with(
+             print::print_range_with(
                  crab::outs(), delta,
                  [this](crab_os &o, const auto &edge) {
                    vert_id src = edge.first.first;
@@ -2993,7 +2990,7 @@ public:
                      << "-->" << *m_rev_vert_map[dst]
                      << ((dst % 2 == 0) ? "+" : "-") << " w=" << edge.second;
                  },
-                 crab::print::fmt_debug());
+                 print::fmt_debug());
              crab::outs() << "\n";);
 
     // JN: we should be fine calling GrOps::apply_delta
@@ -3559,9 +3556,8 @@ public:
 
     CRAB_LOG("octagon", crab::outs()
                             << "Replacing "
-                            << crab::seq(from, crab::print::fmt_debug())
-                            << " with "
-                            << crab::seq(to, crab::print::fmt_debug()) << ":\n"
+                            << print::seq(from, print::fmt_debug()) << " with "
+                            << print::seq(to, print::fmt_debug()) << ":\n"
                             << *this << "\n";);
 
     vert_map_t new_vert_map;

--- a/include/crab/domains/term_equiv.hpp
+++ b/include/crab/domains/term_equiv.hpp
@@ -38,14 +38,15 @@
 #include <crab/domains/abstract_domain.hpp>
 #include <crab/domains/abstract_domain_specialized_traits.hpp>
 #include <crab/domains/backward_assign_operations.hpp>
-#include <crab/domains/intervals.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/intervals.hpp>
 #include <crab/domains/term/inverse.hpp>
 #include <crab/domains/term/simplify.hpp>
 #include <crab/domains/term/term_expr.hpp>
 #include <crab/domains/term/term_operators.hpp>
 #include <crab/numbers/bignums.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 #include <crab/types/varname_factory.hpp>
 
@@ -1533,13 +1534,12 @@ public:
     if (is_top() || is_bottom())
       return;
 
-    CRAB_LOG("term", crab::outs() << "Renaming {"; for (auto v
-                                                        : from) crab::outs()
-                                                   << v << ";";
-             crab::outs() << "} with "; for (auto v
-                                             : to) crab::outs()
-                                        << v << ";";
-             crab::outs() << "}:\n"; crab::outs() << *this << "\n";);
+    CRAB_LOG("term", crab::outs()
+                         << "Renaming "
+                         << crab::seq(from, crab::print::fmt_debug())
+                         << " with " << crab::seq(to, crab::print::fmt_debug())
+                         << ":\n"
+                         << *this << "\n";);
 
     for (unsigned i = 0, sz = from.size(); i < sz; ++i) {
       const variable_t &v = from[i];

--- a/include/crab/domains/term_equiv.hpp
+++ b/include/crab/domains/term_equiv.hpp
@@ -1535,9 +1535,8 @@ public:
       return;
 
     CRAB_LOG("term", crab::outs()
-                         << "Renaming "
-                         << crab::seq(from, crab::print::fmt_debug())
-                         << " with " << crab::seq(to, crab::print::fmt_debug())
+                         << "Renaming " << print::seq(from, print::fmt_debug())
+                         << " with " << print::seq(to, print::fmt_debug())
                          << ":\n"
                          << *this << "\n";);
 

--- a/include/crab/domains/union_find_domain.hpp
+++ b/include/crab/domains/union_find_domain.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <boost/range/iterator_range.hpp>
@@ -199,26 +200,14 @@ private:
   }
 
   void print(crab_os &o) const {
-    o << "({";
-    for (auto it = m_parents.begin(), et = m_parents.end(); it != et;) {
-      element_t key = it->first, value = it->second;
-      o << key << " -> " << value;
-      ++it;
-      if (it != et) {
-        o << ", ";
-      }
-    }
-    o << "}, {";
-    for (auto it = m_classes.begin(), et = m_classes.end(); it != et;) {
-      element_t rep = it->first;
-      const equivalence_class_t &ec = it->second;
-      o << rep << " -> " << *(ec.get_absval());
-      ++it;
-      if (it != et) {
-        o << ", ";
-      }
-    }
-    o << "})";
+    o << "(" << crab::kv(m_parents, crab::print::fmt_set()) << ", ";
+    crab::print::print_range_with(
+        o, m_classes,
+        [](crab_os &o, const auto &p) {
+          o << p.first << " -> " << *(p.second.get_absval());
+        },
+        crab::print::fmt_set());
+    o << ")";
   }
 
   void get_all_members(std::vector<element_t> &out) const {

--- a/include/crab/domains/union_find_domain.hpp
+++ b/include/crab/domains/union_find_domain.hpp
@@ -200,13 +200,13 @@ private:
   }
 
   void print(crab_os &o) const {
-    o << "(" << crab::kv(m_parents, crab::print::fmt_set()) << ", ";
-    crab::print::print_range_with(
+    o << "(" << print::kv(m_parents, print::fmt_set()) << ", ";
+    print::print_range_with(
         o, m_classes,
         [](crab_os &o, const auto &p) {
           o << p.first << " -> " << *(p.second.get_absval());
         },
-        crab::print::fmt_set());
+        print::fmt_set());
     o << ")";
   }
 

--- a/include/crab/domains/wrapped_interval_domain.hpp
+++ b/include/crab/domains/wrapped_interval_domain.hpp
@@ -11,12 +11,13 @@
 #include <crab/domains/abstract_domain_specialized_traits.hpp>
 #include <crab/domains/combined_domains.hpp>
 #include <crab/domains/discrete_domains.hpp>
-#include <crab/domains/interval.hpp>
 #include <crab/domains/inter_abstract_operations.hpp>
+#include <crab/domains/interval.hpp>
 #include <crab/domains/linear_interval_solver.hpp>
 #include <crab/domains/separate_domains.hpp>
 #include <crab/domains/wrapped_interval.hpp>
 #include <crab/numbers/wrapint.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 #include <boost/optional.hpp>
@@ -1908,11 +1909,9 @@ public:
     _product.first() += csts;
 
     linear_constraint_system_t non_overflow_csts;
-    CRAB_LOG(
-        "wrapped-num", crab::outs() << "BEGIN add constraints {"; for (auto c
-                                                                       : csts) {
-          crab::outs() << c << ";";
-        } crab::outs() << "}\n";);
+    CRAB_LOG("wrapped-num",
+            crab::outs() << "BEGIN add constraints "
+                         << crab::seq(csts, crab::print::fmt_debug()) << "\n";);
 
     for (auto c : csts) {
       // rectify of the "unsound" numerical domain

--- a/include/crab/domains/wrapped_interval_domain.hpp
+++ b/include/crab/domains/wrapped_interval_domain.hpp
@@ -1911,7 +1911,7 @@ public:
     linear_constraint_system_t non_overflow_csts;
     CRAB_LOG("wrapped-num",
             crab::outs() << "BEGIN add constraints "
-                         << crab::seq(csts, crab::print::fmt_debug()) << "\n";);
+                         << print::seq(csts, print::fmt_debug()) << "\n";);
 
     for (auto c : csts) {
       // rectify of the "unsound" numerical domain

--- a/include/crab/fixpoint/killgen_fixpoint_iterator.hpp
+++ b/include/crab/fixpoint/killgen_fixpoint_iterator.hpp
@@ -9,6 +9,7 @@
 #include <crab/analysis/graphs/topo_order.hpp>
 #include <crab/cfg/cfg_bgl.hpp>
 #include <crab/support/debug.hpp>
+#include <crab/support/print.hpp>
 #include <crab/support/stats.hpp>
 
 namespace crab {
@@ -161,20 +162,19 @@ public:
       run_bwd_fixpo(order, iterations);
     }
 
-    CRAB_LOG(m_analysis.name(),
-	     crab::outs() << m_analysis.name();
-	     if (m_cfg.has_func_decl()) {
-	       crab::outs() << " for " << m_cfg.get_func_decl();
-	     }
-	     crab::outs() << "\n";
-	     crab::outs() << "fixpoint ordering={";
-             bool first = true; for (auto &v
-                                     : order) {
-               if (!first)
-                 crab::outs() << ",";
-               first = false;
-               crab::outs() << basic_block_traits<basic_block_t>::to_string(v);
-             } crab::outs() << "}\n";);
+    CRAB_LOG(
+        m_analysis.name(), crab::outs() << m_analysis.name();
+        if (m_cfg.has_func_decl()) {
+          crab::outs() << " for " << m_cfg.get_func_decl();
+        } crab::outs()
+        << "\n";
+        crab::outs() << "fixpoint ordering="; crab::print::print_range_with(
+            crab::outs(), order,
+            [](crab_os &o, const auto &v) {
+              o << basic_block_traits<basic_block_t>::to_string(v);
+            },
+            crab::print::fmt_set_tight());
+        crab::outs() << "\n";);
 
     CRAB_LOG(m_analysis.name(), crab::outs() << m_analysis.name() << ": "
                                              << "fixpoint reached in "

--- a/include/crab/fixpoint/killgen_fixpoint_iterator.hpp
+++ b/include/crab/fixpoint/killgen_fixpoint_iterator.hpp
@@ -168,12 +168,12 @@ public:
           crab::outs() << " for " << m_cfg.get_func_decl();
         } crab::outs()
         << "\n";
-        crab::outs() << "fixpoint ordering="; crab::print::print_range_with(
+        crab::outs() << "fixpoint ordering="; print::print_range_with(
             crab::outs(), order,
             [](crab_os &o, const auto &v) {
               o << basic_block_traits<basic_block_t>::to_string(v);
             },
-            crab::print::fmt_set_tight());
+            print::fmt_set_tight());
         crab::outs() << "\n";);
 
     CRAB_LOG(m_analysis.name(), crab::outs() << m_analysis.name() << ": "

--- a/include/crab/support/debug.hpp
+++ b/include/crab/support/debug.hpp
@@ -39,7 +39,8 @@ void CrabEnableVerbosity(unsigned v);
 
 crab_os &get_msg_stream(bool timestamp = true);
 
-template <typename... ArgTypes> inline void ___print___(ArgTypes... args) {
+template <typename... ArgTypes>
+inline void ___print___(const ArgTypes &...args) {
   // trick to expand variadic argument pack without recursion
   using expand_variadic_pack = int[];
   // first zero is to prevent empty braced-init-list

--- a/include/crab/support/debug.hpp
+++ b/include/crab/support/debug.hpp
@@ -11,6 +11,8 @@
 
 namespace crab {
 
+// To print containers or boost::optional values inside log messages, see
+// <crab/support/print.hpp> (print::seq / print::kv / print::opt).
 #ifndef NCRABLOG
 #define CRAB_LOG(TAG, CODE)                                                    \
   do {                                                                         \

--- a/include/crab/support/print.hpp
+++ b/include/crab/support/print.hpp
@@ -1,0 +1,577 @@
+#pragma once
+
+/*
+ * A small facility for printing containers (and optional-like values) to a
+ * crab_os, so that write()/operator<< implementations do not need to
+ * hand-roll separator loops.
+ *
+ * Quick reference (o is a crab_os):
+ *
+ *   o << crab::seq(v);                       // [a, b, c]
+ *   o << crab::seq(v, print::fmt_set());     // {a, b, c}
+ *   o << crab::seq(v).sep("; ").bare();      // a; b; c
+ *   o << crab::kv(m);                        // {k1 -> v1; k2 -> v2}
+ *   o << crab::opt(x);                       // value of *x, or "none"
+ *   o << crab::opt(x, "<absent>");           // custom empty marker
+ *
+ *   print::print_range(o, v, print::fmt_seq_tight());   // [a,b,c]
+ *   print::print_range_with(o, v, fn);       // fn(crab_os&, const elem&)
+ *   print::to_string(x);                     // print anything to a std::string
+ *
+ *   print::separator sep(o, ", ");           // for loops that filter elements
+ *   for (auto &e : v) {                      // or span several sibling loops
+ *     if (skip(e)) continue;
+ *     sep.next() << e;
+ *   }
+ *
+ * Elements are printed by trying, in order: std::pair (first -> second),
+ * container (recurse), optional-like (dereference or print the empty marker),
+ * operator<<, then write(crab_os&). See print_element below for the
+ * rationale of that order.
+ *
+ * Design notes:
+ *
+ * - There is deliberately NO generic operator<<(crab_os&, const T&).
+ *   crab_os's operator<< overloads are non-template members, and bool, float,
+ *   short, enums and T* reach them only by promotion/conversion; a generic
+ *   const T& template would be an identity match and silently steal them.
+ *   The seq/kv/opt wrappers sidestep this: their operator<< is a plain
+ *   non-template hidden friend that can only ever match the wrapper.
+ *
+ * - Raw pointers are NEVER dereferenced automatically. A raw T* keeps
+ *   binding to crab_os::operator<<(const void*) and prints as an address,
+ *   as it always has. If a caller wants the pointee they must say so
+ *   explicitly with crab::opt(p).
+ *
+ * - This header is C++14: no if constexpr, no std::void_t, no fold
+ *   expressions, hence the make_void / priority_tag machinery below.
+ */
+
+#include <crab/support/os.hpp>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace crab {
+namespace print {
+
+/*
+ * Describes ONE level of container printing: brackets, separator, the arrow
+ * between the members of a pair, what to print for an empty container, the
+ * marker for an empty optional-like element, and whether the separator also
+ * trails the last element (the "{a;b;c;}" debug style).
+ *
+ * Nested elements do not inherit the enclosing format: a nested container is
+ * printed with its own type default (fmt_map() if its elements are pairs,
+ * fmt_seq() otherwise). So map<K, vector<V>> prints {k -> [a, b], ...}.
+ *
+ * The setters return a modified copy, so formats chain:
+ *   format().brackets("{", "}").sep("; ")
+ */
+class format {
+public:
+  const char *m_open = "[";
+  const char *m_close = "]";
+  const char *m_sep = ", ";
+  const char *m_arrow = " -> ";
+  // printed instead of m_open/m_close when the range is empty (nullptr means
+  // print m_open followed by m_close)
+  const char *m_empty = nullptr;
+  // marker for an empty optional-like element. "none" matches the existing
+  // convention (e.g. cfg.hpp); it is not "_|_", which in crab means bottom,
+  // a lattice value -- an absent value is not a bottom value.
+  const char *m_none = "none";
+  bool m_trailing = false;
+
+  format sep(const char *s) const {
+    format f(*this);
+    f.m_sep = s;
+    return f;
+  }
+  format brackets(const char *open, const char *close) const {
+    format f(*this);
+    f.m_open = open;
+    f.m_close = close;
+    return f;
+  }
+  format bare() const { return brackets("", ""); }
+  format arrow(const char *a) const {
+    format f(*this);
+    f.m_arrow = a;
+    return f;
+  }
+  format empty(const char *e) const {
+    format f(*this);
+    f.m_empty = e;
+    return f;
+  }
+  format none(const char *n) const {
+    format f(*this);
+    f.m_none = n;
+    return f;
+  }
+  format trailing(bool b = true) const {
+    format f(*this);
+    f.m_trailing = b;
+    return f;
+  }
+};
+
+/*
+ * Presets, named after the conventions they reproduce so that migrating an
+ * existing printer is a lookup rather than a judgement call.
+ */
+// [a, b, c]
+inline format fmt_seq() { return format(); }
+// [a,b,c]
+inline format fmt_seq_tight() { return format().sep(","); }
+// {a, b, c}
+inline format fmt_set() { return format().brackets("{", "}"); }
+// {a,b,c}
+inline format fmt_set_tight() { return fmt_set().sep(","); }
+// {k1 -> v1; k2 -> v2} -- the patricia-tree map printers
+inline format fmt_map() { return format().brackets("{", "}").sep("; "); }
+// same bytes as fmt_map(); named separately so patricia call sites document
+// which convention they came from
+inline format fmt_patricia() { return fmt_map(); }
+// [|v1, v2|] -- the graph printers
+inline format fmt_graph() { return format().brackets("[|", "|]"); }
+// {a;b;c;} -- the CRAB_LOG debug loops
+inline format fmt_debug() {
+  return format().brackets("{", "}").sep(";").trailing();
+}
+
+/*
+ * A stateful joiner for the loops that cannot become a single range call:
+ * loops that `continue`-filter elements, or two sibling loops sharing one
+ * "first" flag (e.g. the split_dbm printer). The first call to next() prints
+ * nothing; every later call prints the separator. Either way it returns the
+ * stream, so the natural use is:
+ *
+ *   separator sep(o, ", ");
+ *   for (...) { if (filtered) continue; sep.next() << elem; }
+ */
+class separator {
+  crab_os &m_o;
+  const char *m_sep;
+  bool m_first;
+
+public:
+  separator(crab_os &o, const char *sep = ", ")
+      : m_o(o), m_sep(sep), m_first(true) {}
+  crab_os &next() {
+    if (!m_first) {
+      m_o << m_sep;
+    }
+    m_first = false;
+    return m_o;
+  }
+  // true iff next() has not fired yet -- for "print a footer only if we
+  // printed anything" call sites
+  bool first() const { return m_first; }
+  void reset() { m_first = true; }
+};
+
+template <typename Range>
+void print_range(crab_os &o, const Range &r, const format &fmt);
+
+namespace detail {
+
+// C++14 has no std::void_t. Hand-rolled through a struct rather than a
+// direct alias: with a direct alias some compilers do not guarantee that
+// unused alias arguments trigger SFINAE (CWG 1558).
+template <typename...> struct make_void { using type = void; };
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
+
+// Rank ordering for the dispatch ladder below: an argument of type
+// priority_tag<N> prefers an overload taking priority_tag<N> over one taking
+// priority_tag<N-1> (derived-to-base conversion), so ranks are tried
+// highest-first and SFINAE'd-out ranks fall through.
+template <unsigned N> struct priority_tag : priority_tag<N - 1> {};
+template <> struct priority_tag<0> {};
+
+template <typename T> struct always_false : std::false_type {};
+
+template <typename T> struct is_pair : std::false_type {};
+template <typename A, typename B>
+struct is_pair<std::pair<A, B>> : std::true_type {};
+
+// Ranges are detected through MEMBER begin()/end() only, never std::begin:
+// with std::begin every string literal (const char[N]) would count as a
+// range. std::string is excluded explicitly, and the reason is nesting, not
+// ambiguity: it has member begin()/end(), so without the exclusion
+// vector<string> would print [[h,i],[t,h,e,r,e]] instead of [hi, there].
+template <typename T, typename = void>
+struct has_member_begin_end : std::false_type {};
+template <typename T>
+struct has_member_begin_end<T,
+                            void_t<decltype(std::declval<const T &>().begin()),
+                                   decltype(std::declval<const T &>().end())>>
+    : std::true_type {};
+
+template <typename T>
+struct is_range
+    : std::integral_constant<bool, has_member_begin_end<T>::value &&
+                                       !std::is_same<T, std::string>::value> {};
+
+template <typename T, typename = void>
+struct has_os_insert : std::false_type {};
+template <typename T>
+struct has_os_insert<
+    T, void_t<decltype(std::declval<crab_os &>() << std::declval<const T &>())>>
+    : std::true_type {};
+
+// Probes T&, not const T&: a few types declare write(crab_os&) non-const
+// (e.g. fwd_analyzer), and a const-only probe would miss them. A const
+// write() is still callable through a T&, so this probe accepts both.
+template <typename T, typename = void> struct has_write : std::false_type {};
+template <typename T>
+struct has_write<
+    T, void_t<decltype(std::declval<T &>().write(std::declval<crab_os &>()))>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct has_deref : std::false_type {};
+template <typename T>
+struct has_deref<T, void_t<decltype(*std::declval<const T &>())>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct is_bool_testable : std::false_type {};
+template <typename T>
+struct is_bool_testable<
+    T, void_t<decltype(static_cast<bool>(std::declval<const T &>()))>>
+    : std::true_type {};
+
+// Structural detection of boost::optional, std::shared_ptr, std::unique_ptr
+// (and std::optional under C++17) without including any of their headers:
+// dereferenceable and contextually convertible to bool. Ranges keep range
+// semantics, and raw pointers are excluded on purpose -- see the "never
+// auto-dereference a raw pointer" note at the top of this file.
+template <typename T>
+struct is_optional_like
+    : std::integral_constant<
+          bool, has_deref<T>::value && is_bool_testable<T>::value &&
+                    !is_range<T>::value && !std::is_pointer<T>::value> {};
+
+// For a nested range printed as an element: its own type default.
+template <typename Range> struct range_element {
+  using type = typename std::decay<
+      decltype(*std::declval<const Range &>().begin())>::type;
+};
+
+template <typename Range> inline format default_format() {
+  return is_pair<typename range_element<Range>::type>::value ? fmt_map()
+                                                             : fmt_seq();
+}
+
+/*
+ * The element dispatch ladder. print_element(o, x, fmt) prints one element
+ * by trying, highest rank first:
+ *
+ *   pair > range > optional-like > operator<< > write() > static_assert
+ *
+ * operator<< is preferred over write(): the two agree for crab's own types,
+ * but templates like separate_domains are instantiated by downstream clients
+ * with their types, where they can differ, and a type's own operator<< is
+ * the author's stated intent.
+ *
+ * Ranges are preferred over operator<<: has_os_insert matches through
+ * implicit conversions (an enum or a bool-convertible type "streams" as an
+ * integer), which is almost never the intended way to print a
+ * container-like type.
+ *
+ * The fmt argument supplies this level's pair arrow and optional-empty
+ * marker only; a nested range starts over with its own type default.
+ */
+template <typename T>
+void print_element(crab_os &o, const T &x, const format &fmt);
+
+template <typename A, typename B>
+void print_element_impl(crab_os &o, const std::pair<A, B> &p, const format &fmt,
+                        priority_tag<4>) {
+  print_element(o, p.first, fmt);
+  o << fmt.m_arrow;
+  print_element(o, p.second, fmt);
+}
+
+template <typename T,
+          typename std::enable_if<is_range<T>::value, int>::type = 0>
+void print_element_impl(crab_os &o, const T &r, const format &,
+                        priority_tag<3>) {
+  print_range(o, r, default_format<T>());
+}
+
+template <typename T,
+          typename std::enable_if<is_optional_like<T>::value, int>::type = 0>
+void print_element_impl(crab_os &o, const T &x, const format &fmt,
+                        priority_tag<2>) {
+  if (x) {
+    print_element(o, *x, fmt);
+  } else {
+    o << fmt.m_none;
+  }
+}
+
+template <typename T,
+          typename std::enable_if<has_os_insert<T>::value, int>::type = 0>
+void print_element_impl(crab_os &o, const T &x, const format &,
+                        priority_tag<1>) {
+  o << x;
+}
+
+template <typename T,
+          typename std::enable_if<has_write<T>::value, int>::type = 0>
+void print_element_impl(crab_os &o, const T &x, const format &,
+                        priority_tag<0>) {
+  // const_cast because a few write(crab_os&) methods are missing a const
+  // qualifier (see has_write above); printing does not mutate.
+  const_cast<T &>(x).write(o);
+}
+
+template <typename T> struct is_printable_element {
+  static constexpr bool value = is_pair<T>::value || is_range<T>::value ||
+                                is_optional_like<T>::value ||
+                                has_os_insert<T>::value || has_write<T>::value;
+};
+
+template <typename T>
+void print_element(crab_os &o, const T &x, const format &fmt) {
+  static_assert(is_printable_element<T>::value,
+                "crab::print: this element type is not printable. It needs "
+                "an operator<<(crab_os&, const T&) or a write(crab_os&) "
+                "method; alternatively use print_range_with with an explicit "
+                "callback.");
+  print_element_impl(o, x, fmt, priority_tag<4>{});
+}
+
+} // namespace detail
+
+template <typename Range>
+void print_range(crab_os &o, const Range &r, const format &fmt) {
+  auto it = r.begin();
+  auto end = r.end();
+  if (it == end && fmt.m_empty) {
+    o << fmt.m_empty;
+    return;
+  }
+  o << fmt.m_open;
+  for (bool first = true; it != end; ++it, first = false) {
+    // in the trailing style the separator is emitted after every element
+    // instead of between elements
+    if (!first && !fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+    detail::print_element(o, *it, fmt);
+    // the "{a;b;c;}" style: the separator also trails the last element
+    if (fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+  }
+  o << fmt.m_close;
+}
+
+template <typename Range> void print_range(crab_os &o, const Range &r) {
+  print_range(o, r, fmt_seq());
+}
+
+template <typename It>
+void print_range(crab_os &o, It first, It last, const format &fmt) {
+  if (first == last && fmt.m_empty) {
+    o << fmt.m_empty;
+    return;
+  }
+  o << fmt.m_open;
+  for (It it = first; it != last; ++it) {
+    if (it != first && !fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+    detail::print_element(o, *it, fmt);
+    if (fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+  }
+  o << fmt.m_close;
+}
+
+template <typename It> void print_range(crab_os &o, It first, It last) {
+  print_range(o, first, last, fmt_seq());
+}
+
+/*
+ * Like print_range, but each element is printed by fn(o, elem) instead of
+ * the dispatch ladder. fn takes the stream (matching the write(crab_os&)
+ * convention), so the same callback works against a crab_string_os.
+ *
+ * Use this where the element printing must be pinned down explicitly, e.g.
+ * converting a printer whose Key/Value are client-supplied template
+ * parameters: an explicit write-calling callback is byte-exact by
+ * construction, independent of what operator<<s the client type has.
+ */
+template <typename Range, typename Fn>
+void print_range_with(crab_os &o, const Range &r, Fn fn, const format &fmt) {
+  auto it = r.begin();
+  auto end = r.end();
+  if (it == end && fmt.m_empty) {
+    o << fmt.m_empty;
+    return;
+  }
+  o << fmt.m_open;
+  for (bool first = true; it != end; ++it, first = false) {
+    // in the trailing style the separator is emitted after every element
+    // instead of between elements
+    if (!first && !fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+    fn(o, *it);
+    if (fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+  }
+  o << fmt.m_close;
+}
+
+template <typename Range, typename Fn>
+void print_range_with(crab_os &o, const Range &r, Fn fn) {
+  print_range_with(o, r, fn, fmt_seq());
+}
+
+template <typename It, typename Fn>
+void print_range_with(crab_os &o, It first, It last, Fn fn, const format &fmt) {
+  if (first == last && fmt.m_empty) {
+    o << fmt.m_empty;
+    return;
+  }
+  o << fmt.m_open;
+  for (It it = first; it != last; ++it) {
+    if (it != first && !fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+    fn(o, *it);
+    if (fmt.m_trailing) {
+      o << fmt.m_sep;
+    }
+  }
+  o << fmt.m_close;
+}
+
+template <typename It, typename Fn>
+void print_range_with(crab_os &o, It first, It last, Fn fn) {
+  print_range_with(o, first, last, fn, fmt_seq());
+}
+
+// Print anything the ladder accepts (including the seq/kv/opt wrappers)
+// to a std::string, folding the usual crab_string_os dance.
+template <typename T> std::string to_string(const T &x) {
+  crab_string_os os;
+  detail::print_element(os, x, format());
+  return os.str();
+}
+
+} // namespace print
+
+/*
+ * The ergonomic wrappers: o << crab::seq(v), o << crab::kv(m),
+ * o << crab::opt(x).
+ *
+ * Each holds a POINTER to the wrapped object, not a reference: CRAB_ERROR /
+ * CRAB_WARN funnel their arguments through ___print___ by value, and a
+ * reference member would make those copies dangle-prone; a pointer member
+ * copies safely. The wrappers are still view types -- they must not outlive
+ * the wrapped object, so use them directly in a print expression rather
+ * than storing them.
+ *
+ * operator<< is a hidden friend: a non-template function that only ADL can
+ * find and that can only ever match the wrapper, so it cannot interfere
+ * with crab_os's own non-template operator<< overloads.
+ */
+
+// A range printed as a sequence: o << crab::seq(v) -> [a, b, c]
+template <typename Range> class seq_ref {
+  const Range *m_r;
+  print::format m_fmt;
+
+public:
+  seq_ref(const Range &r, const print::format &fmt) : m_r(&r), m_fmt(fmt) {}
+  seq_ref sep(const char *s) const { return seq_ref(*m_r, m_fmt.sep(s)); }
+  seq_ref brackets(const char *open, const char *close) const {
+    return seq_ref(*m_r, m_fmt.brackets(open, close));
+  }
+  seq_ref bare() const { return seq_ref(*m_r, m_fmt.bare()); }
+  seq_ref empty(const char *e) const { return seq_ref(*m_r, m_fmt.empty(e)); }
+  seq_ref trailing(bool b = true) const {
+    return seq_ref(*m_r, m_fmt.trailing(b));
+  }
+  void write(crab_os &o) const { print::print_range(o, *m_r, m_fmt); }
+  friend crab_os &operator<<(crab_os &o, const seq_ref &s) {
+    s.write(o);
+    return o;
+  }
+};
+
+template <typename Range> seq_ref<Range> seq(const Range &r) {
+  return seq_ref<Range>(r, print::fmt_seq());
+}
+template <typename Range>
+seq_ref<Range> seq(const Range &r, const print::format &fmt) {
+  return seq_ref<Range>(r, fmt);
+}
+
+// A range of pairs printed as a map: o << crab::kv(m) -> {k1 -> v1; k2 -> v2}
+template <typename Map> class kv_ref {
+  const Map *m_m;
+  print::format m_fmt;
+
+public:
+  kv_ref(const Map &m, const print::format &fmt) : m_m(&m), m_fmt(fmt) {}
+  kv_ref sep(const char *s) const { return kv_ref(*m_m, m_fmt.sep(s)); }
+  kv_ref brackets(const char *open, const char *close) const {
+    return kv_ref(*m_m, m_fmt.brackets(open, close));
+  }
+  kv_ref bare() const { return kv_ref(*m_m, m_fmt.bare()); }
+  kv_ref arrow(const char *a) const { return kv_ref(*m_m, m_fmt.arrow(a)); }
+  kv_ref empty(const char *e) const { return kv_ref(*m_m, m_fmt.empty(e)); }
+  void write(crab_os &o) const { print::print_range(o, *m_m, m_fmt); }
+  friend crab_os &operator<<(crab_os &o, const kv_ref &m) {
+    m.write(o);
+    return o;
+  }
+};
+
+template <typename Map> kv_ref<Map> kv(const Map &m) {
+  return kv_ref<Map>(m, print::fmt_map());
+}
+template <typename Map> kv_ref<Map> kv(const Map &m, const print::format &fmt) {
+  return kv_ref<Map>(m, fmt);
+}
+
+// An optional-like (or raw pointer, made explicit here) printed as its
+// value, or a marker when empty: o << crab::opt(x) -> *x or "none"
+template <typename T> class opt_ref {
+  const T *m_x;
+  const char *m_none;
+
+public:
+  opt_ref(const T &x, const char *none) : m_x(&x), m_none(none) {}
+  void write(crab_os &o) const {
+    static_assert(print::detail::has_deref<T>::value &&
+                      print::detail::is_bool_testable<T>::value,
+                  "crab::opt requires an optional-like type (dereferenceable "
+                  "and contextually convertible to bool) or a raw pointer");
+    if (static_cast<bool>(*m_x)) {
+      print::detail::print_element(o, **m_x, print::format().none(m_none));
+    } else {
+      o << m_none;
+    }
+  }
+  friend crab_os &operator<<(crab_os &o, const opt_ref &x) {
+    x.write(o);
+    return o;
+  }
+};
+
+template <typename T> opt_ref<T> opt(const T &x, const char *none = "none") {
+  return opt_ref<T>(x, none);
+}
+
+} // namespace crab

--- a/include/crab/support/print.hpp
+++ b/include/crab/support/print.hpp
@@ -24,10 +24,11 @@
  *     sep.next() << e;
  *   }
  *
- * Elements are printed by trying, in order: std::pair (first -> second),
- * container (recurse), optional-like (dereference or print the empty marker),
- * operator<<, then write(crab_os&). See print_element below for the
- * rationale of that order.
+ * Elements are printed by trying, in order: operator<< (so anything already
+ * streamable prints exactly as before), std::pair (first -> second),
+ * container (recurse), optional-like (dereference or print the empty
+ * marker), then write(crab_os&). See print_element below for the rationale
+ * of that order.
  *
  * Design notes:
  *
@@ -133,7 +134,11 @@ inline format fmt_set_tight() { return fmt_set().sep(","); }
 // {k1 -> v1; k2 -> v2} -- the patricia-tree map printers
 inline format fmt_map() { return format().brackets("{", "}").sep("; "); }
 // same bytes as fmt_map(); named separately so patricia call sites document
-// which convention they came from
+// which convention they came from. NOTE: patricia-tree iterators yield a
+// binding type that is NOT std::pair (it only has first/second members), so
+// the automatic pair rank does not fire for them -- print a patricia map
+// with print_range_with and an explicit "k -> v" callback, passing this
+// format (see region_domain.hpp for an example).
 inline format fmt_patricia() { return fmt_map(); }
 // [|v1, v2|] -- the graph printers
 inline format fmt_graph() { return format().brackets("[|", "|]"); }
@@ -269,17 +274,25 @@ template <typename Range> inline format default_format() {
  * The element dispatch ladder. print_element(o, x, fmt) prints one element
  * by trying, highest rank first:
  *
- *   pair > range > optional-like > operator<< > write() > static_assert
+ *   operator<< > pair > range > optional-like > write() > static_assert
  *
- * operator<< is preferred over write(): the two agree for crab's own types,
- * but templates like separate_domains are instantiated by downstream clients
- * with their types, where they can differ, and a type's own operator<< is
- * the author's stated intent.
+ * operator<< is the TOP rank on purpose: an element that can already be
+ * streamed keeps streaming exactly as it always has, so routing it through
+ * the facility can never change its printed bytes. This matters because
+ * several crab types have BOTH iterators and an operator<< (e.g.
+ * linear_constraint_t iterates its terms); ranking ranges higher would
+ * silently print those as bracketed element lists.
  *
- * Ranges are preferred over operator<<: has_os_insert matches through
- * implicit conversions (an enum or a bool-convertible type "streams" as an
- * integer), which is almost never the intended way to print a
- * container-like type.
+ * operator<< is also preferred over write(): the two agree for crab's own
+ * types, but templates like separate_domains are instantiated by downstream
+ * clients with their types, where they can differ, and a type's own
+ * operator<< is the author's stated intent.
+ *
+ * Caveat of the top rank: has_os_insert matches through implicit
+ * conversions, so an optional-like type with an IMPLICIT operator bool
+ * would stream as 0/1 instead of dereferencing. boost::optional,
+ * shared_ptr and unique_ptr all declare theirs explicit, so they take the
+ * optional-like rank as intended.
  *
  * The fmt argument supplies this level's pair arrow and optional-empty
  * marker only; a nested range starts over with its own type default.
@@ -287,9 +300,16 @@ template <typename Range> inline format default_format() {
 template <typename T>
 void print_element(crab_os &o, const T &x, const format &fmt);
 
+template <typename T,
+          typename std::enable_if<has_os_insert<T>::value, int>::type = 0>
+void print_element_impl(crab_os &o, const T &x, const format &,
+                        priority_tag<4>) {
+  o << x;
+}
+
 template <typename A, typename B>
 void print_element_impl(crab_os &o, const std::pair<A, B> &p, const format &fmt,
-                        priority_tag<4>) {
+                        priority_tag<3>) {
   print_element(o, p.first, fmt);
   o << fmt.m_arrow;
   print_element(o, p.second, fmt);
@@ -298,14 +318,14 @@ void print_element_impl(crab_os &o, const std::pair<A, B> &p, const format &fmt,
 template <typename T,
           typename std::enable_if<is_range<T>::value, int>::type = 0>
 void print_element_impl(crab_os &o, const T &r, const format &,
-                        priority_tag<3>) {
+                        priority_tag<2>) {
   print_range(o, r, default_format<T>());
 }
 
 template <typename T,
           typename std::enable_if<is_optional_like<T>::value, int>::type = 0>
 void print_element_impl(crab_os &o, const T &x, const format &fmt,
-                        priority_tag<2>) {
+                        priority_tag<1>) {
   if (x) {
     print_element(o, *x, fmt);
   } else {
@@ -314,18 +334,15 @@ void print_element_impl(crab_os &o, const T &x, const format &fmt,
 }
 
 template <typename T,
-          typename std::enable_if<has_os_insert<T>::value, int>::type = 0>
-void print_element_impl(crab_os &o, const T &x, const format &,
-                        priority_tag<1>) {
-  o << x;
-}
-
-template <typename T,
           typename std::enable_if<has_write<T>::value, int>::type = 0>
 void print_element_impl(crab_os &o, const T &x, const format &,
                         priority_tag<0>) {
   // const_cast because a few write(crab_os&) methods are missing a const
-  // qualifier (see has_write above); printing does not mutate.
+  // qualifier (see has_write above). This rank REQUIRES that write() does
+  // not actually mutate: calling a genuinely mutating write() on an object
+  // that was defined const would be undefined behavior. A write() that
+  // mutates its object is broken for printing anyway; fix its signature
+  // rather than relying on this rank.
   const_cast<T &>(x).write(o);
 }
 

--- a/include/crab/support/print.hpp
+++ b/include/crab/support/print.hpp
@@ -5,14 +5,18 @@
  * crab_os, so that write()/operator<< implementations do not need to
  * hand-roll separator loops.
  *
+ * Everything lives in namespace crab::print. Code inside namespace crab
+ * writes print::seq(v); downstream code writes crab::print::seq(v), or
+ * abbreviates with `namespace cp = crab::print;`.
+ *
  * Quick reference (o is a crab_os):
  *
- *   o << crab::seq(v);                       // [a, b, c]
- *   o << crab::seq(v, print::fmt_set());     // {a, b, c}
- *   o << crab::seq(v).sep("; ").bare();      // a; b; c
- *   o << crab::kv(m);                        // {k1 -> v1; k2 -> v2}
- *   o << crab::opt(x);                       // value of *x, or "none"
- *   o << crab::opt(x, "<absent>");           // custom empty marker
+ *   o << print::seq(v);                      // [a, b, c]
+ *   o << print::seq(v, print::fmt_set());    // {a, b, c}
+ *   o << print::seq(v).sep("; ").bare();     // a; b; c
+ *   o << print::kv(m);                       // {k1 -> v1; k2 -> v2}
+ *   o << print::opt(x);                      // value of *x, or "none"
+ *   o << print::opt(x, "<absent>");          // custom empty marker
  *
  *   print::print_range(o, v, print::fmt_seq_tight());   // [a,b,c]
  *   print::print_range_with(o, v, fn);       // fn(crab_os&, const elem&)
@@ -23,6 +27,19 @@
  *     if (skip(e)) continue;
  *     sep.next() << e;
  *   }
+ *
+ * Before/after -- the typical hand-rolled separator loop
+ *
+ *   o << "{";
+ *   for (auto it = m.begin(); it != m.end();) {
+ *     o << it->first << " -> " << it->second;
+ *     if (++it != m.end()) { o << "; "; }
+ *   }
+ *   o << "}";
+ *
+ * becomes the one-liner
+ *
+ *   o << print::kv(m);
  *
  * Elements are printed by trying, in order: operator<< (so anything already
  * streamable prints exactly as before), std::pair (first -> second),
@@ -42,7 +59,7 @@
  * - Raw pointers are NEVER dereferenced automatically. A raw T* keeps
  *   binding to crab_os::operator<<(const void*) and prints as an address,
  *   as it always has. If a caller wants the pointee they must say so
- *   explicitly with crab::opt(p).
+ *   explicitly with print::opt(p).
  *
  * - This header is C++14: no if constexpr, no std::void_t, no fold
  *   expressions, hence the make_void / priority_tag machinery below.
@@ -485,11 +502,18 @@ template <typename T> std::string to_string(const T &x) {
   return os.str();
 }
 
-} // namespace print
-
 /*
- * The ergonomic wrappers: o << crab::seq(v), o << crab::kv(m),
- * o << crab::opt(x).
+ * The ergonomic wrappers: o << print::seq(v), o << print::kv(m),
+ * o << print::opt(x).
+ *
+ * seq_ref/kv_ref/opt_ref versus the print_range/print_range_with functions
+ * above: one implementation, two entry styles. seq_ref::write() simply
+ * delegates to print_range(), so both print the same bytes. Use the wrapper
+ * form in operator<< chains and as CRAB_ERROR/CRAB_WARN arguments -- a
+ * wrapper is a streamable value. Use the function forms inside larger
+ * write() bodies: they print immediately, and print_range_with takes an
+ * explicit per-element callback for when element printing must be pinned
+ * down (see its comment above).
  *
  * Each holds a POINTER to the wrapped object, not a reference: CRAB_ERROR /
  * CRAB_WARN funnel their arguments through ___print___ by value, and a
@@ -503,13 +527,13 @@ template <typename T> std::string to_string(const T &x) {
  * with crab_os's own non-template operator<< overloads.
  */
 
-// A range printed as a sequence: o << crab::seq(v) -> [a, b, c]
+// A range printed as a sequence: o << print::seq(v) -> [a, b, c]
 template <typename Range> class seq_ref {
   const Range *m_r;
-  print::format m_fmt;
+  format m_fmt;
 
 public:
-  seq_ref(const Range &r, const print::format &fmt) : m_r(&r), m_fmt(fmt) {}
+  seq_ref(const Range &r, const format &fmt) : m_r(&r), m_fmt(fmt) {}
   seq_ref sep(const char *s) const { return seq_ref(*m_r, m_fmt.sep(s)); }
   seq_ref brackets(const char *open, const char *close) const {
     return seq_ref(*m_r, m_fmt.brackets(open, close));
@@ -519,7 +543,7 @@ public:
   seq_ref trailing(bool b = true) const {
     return seq_ref(*m_r, m_fmt.trailing(b));
   }
-  void write(crab_os &o) const { print::print_range(o, *m_r, m_fmt); }
+  void write(crab_os &o) const { print_range(o, *m_r, m_fmt); }
   friend crab_os &operator<<(crab_os &o, const seq_ref &s) {
     s.write(o);
     return o;
@@ -527,20 +551,20 @@ public:
 };
 
 template <typename Range> seq_ref<Range> seq(const Range &r) {
-  return seq_ref<Range>(r, print::fmt_seq());
+  return seq_ref<Range>(r, fmt_seq());
 }
 template <typename Range>
-seq_ref<Range> seq(const Range &r, const print::format &fmt) {
+seq_ref<Range> seq(const Range &r, const format &fmt) {
   return seq_ref<Range>(r, fmt);
 }
 
-// A range of pairs printed as a map: o << crab::kv(m) -> {k1 -> v1; k2 -> v2}
+// A range of pairs printed as a map: o << print::kv(m) -> {k1 -> v1; k2 -> v2}
 template <typename Map> class kv_ref {
   const Map *m_m;
-  print::format m_fmt;
+  format m_fmt;
 
 public:
-  kv_ref(const Map &m, const print::format &fmt) : m_m(&m), m_fmt(fmt) {}
+  kv_ref(const Map &m, const format &fmt) : m_m(&m), m_fmt(fmt) {}
   kv_ref sep(const char *s) const { return kv_ref(*m_m, m_fmt.sep(s)); }
   kv_ref brackets(const char *open, const char *close) const {
     return kv_ref(*m_m, m_fmt.brackets(open, close));
@@ -548,7 +572,7 @@ public:
   kv_ref bare() const { return kv_ref(*m_m, m_fmt.bare()); }
   kv_ref arrow(const char *a) const { return kv_ref(*m_m, m_fmt.arrow(a)); }
   kv_ref empty(const char *e) const { return kv_ref(*m_m, m_fmt.empty(e)); }
-  void write(crab_os &o) const { print::print_range(o, *m_m, m_fmt); }
+  void write(crab_os &o) const { print_range(o, *m_m, m_fmt); }
   friend crab_os &operator<<(crab_os &o, const kv_ref &m) {
     m.write(o);
     return o;
@@ -556,14 +580,14 @@ public:
 };
 
 template <typename Map> kv_ref<Map> kv(const Map &m) {
-  return kv_ref<Map>(m, print::fmt_map());
+  return kv_ref<Map>(m, fmt_map());
 }
-template <typename Map> kv_ref<Map> kv(const Map &m, const print::format &fmt) {
+template <typename Map> kv_ref<Map> kv(const Map &m, const format &fmt) {
   return kv_ref<Map>(m, fmt);
 }
 
 // An optional-like (or raw pointer, made explicit here) printed as its
-// value, or a marker when empty: o << crab::opt(x) -> *x or "none"
+// value, or a marker when empty: o << print::opt(x) -> *x or "none"
 template <typename T> class opt_ref {
   const T *m_x;
   const char *m_none;
@@ -571,12 +595,13 @@ template <typename T> class opt_ref {
 public:
   opt_ref(const T &x, const char *none) : m_x(&x), m_none(none) {}
   void write(crab_os &o) const {
-    static_assert(print::detail::has_deref<T>::value &&
-                      print::detail::is_bool_testable<T>::value,
-                  "crab::opt requires an optional-like type (dereferenceable "
-                  "and contextually convertible to bool) or a raw pointer");
+    static_assert(detail::has_deref<T>::value &&
+                      detail::is_bool_testable<T>::value,
+                  "crab::print::opt requires an optional-like type "
+                  "(dereferenceable and contextually convertible to bool) or "
+                  "a raw pointer");
     if (static_cast<bool>(*m_x)) {
-      print::detail::print_element(o, **m_x, print::format().none(m_none));
+      detail::print_element(o, **m_x, format().none(m_none));
     } else {
       o << m_none;
     }
@@ -591,4 +616,5 @@ template <typename T> opt_ref<T> opt(const T &x, const char *none = "none") {
   return opt_ref<T>(x, none);
 }
 
+} // namespace print
 } // namespace crab

--- a/lib/array_adaptive_impl.cpp
+++ b/lib/array_adaptive_impl.cpp
@@ -534,9 +534,8 @@ void offset_map_t::get_overlap_cells(const offset_t &o, uint64_t size,
   CRAB_LOG("array-adaptive-overlap",
            crab::outs() << "**Overlap set between \n"
                         << *this << "\nand "
-                        << "(" << o << "," << size
-                        << ")=" << crab::seq(out, crab::print::fmt_set_tight())
-                        << "\n";);
+                        << "(" << o << "," << size << ")="
+                        << print::seq(out, print::fmt_set_tight()) << "\n";);
 }
 
 void offset_map_t::clear(void) { m_map.clear(); }
@@ -548,7 +547,7 @@ void offset_map_t::write(crab::crab_os &o) const {
     for (auto it = m_map.begin(), et = m_map.end(); it != et; ++it) {
       const cell_set_t &cells = it->second;
       o << "{";
-      crab::print::separator sep(o, ",");
+      print::separator sep(o, ",");
       for (auto const &c : cells) {
         if (c.is_removed()) {
           continue;

--- a/lib/array_adaptive_impl.cpp
+++ b/lib/array_adaptive_impl.cpp
@@ -2,6 +2,7 @@
 #include <crab/domains/interval.hpp>
 #include <crab/support/debug.hpp>
 #include <crab/support/os.hpp>
+#include <crab/support/print.hpp>
 
 namespace crab {
 namespace domains {
@@ -530,19 +531,12 @@ void offset_map_t::get_overlap_cells(const offset_t &o, uint64_t size,
     erase_cell(c);
   }
 
-  CRAB_LOG(
-      "array-adaptive-overlap", crab::outs()
-                                    << "**Overlap set between \n"
-                                    << *this << "\nand "
-                                    << "(" << o << "," << size << ")={";
-      for (unsigned i = 0, e = out.size(); i < e;) {
-        crab::outs() << out[i];
-        ++i;
-        if (i < e) {
-          crab::outs() << ",";
-        }
-      } crab::outs()
-      << "}\n";);
+  CRAB_LOG("array-adaptive-overlap",
+           crab::outs() << "**Overlap set between \n"
+                        << *this << "\nand "
+                        << "(" << o << "," << size
+                        << ")=" << crab::seq(out, crab::print::fmt_set_tight())
+                        << "\n";);
 }
 
 void offset_map_t::clear(void) { m_map.clear(); }
@@ -554,16 +548,12 @@ void offset_map_t::write(crab::crab_os &o) const {
     for (auto it = m_map.begin(), et = m_map.end(); it != et; ++it) {
       const cell_set_t &cells = it->second;
       o << "{";
-      for (auto cit = cells.begin(), cet = cells.end(); cit != cet;) {
-        if ((*cit).is_removed()) {
-          ++cit;
+      crab::print::separator sep(o, ",");
+      for (auto const &c : cells) {
+        if (c.is_removed()) {
           continue;
         }
-        o << *cit;
-        ++cit;
-        if (cit != cet) {
-          o << ",";
-        }
+        sep.next() << c;
       }
       o << "}";
     }


### PR DESCRIPTION
## Motivation

crab has no shared way to print an STL container to a `crab_os`, so every
domain and analysis hand-rolls its own separator loop. A sweep of `include/` +
`lib/` found ~105 such loops across ~50 `write`/`dump`/`operator<<` functions,
using three different separator idioms and five disagreeing bracket
conventions, plus 8 named ad-hoc helpers (three of them byte-identical copies
of the same vector printer). Separately, `boost::optional` — used ~380 times in
`include/` — cannot be printed at all today: `o << opt` does not compile, so
every debug print of one is a manual `if (opt) ... else` at the call site.

## What this adds

One self-contained C++14 header, `include/crab/support/print.hpp` (no `.cpp`,
no change to `os.hpp` or any build file):

```cpp
o << crab::seq(v);                        // [a, b, c]
o << crab::seq(v, print::fmt_set());      // {a, b, c}
o << crab::seq(v).sep("; ").bare();       // a; b; c
o << crab::kv(m);                         // {k1 -> v1; k2 -> v2}
o << crab::opt(x);                        // *x, or "none" when empty
print::print_range_with(o, r, fn, fmt);   // fn(crab_os&, const Elem&)
print::separator sep(o, ", ");            // for loops that filter elements or
for (...) { ...; sep.next() << e; }       // share a "first" flag across loops
print::to_string(x);                      // anything -> std::string
```

Elements dispatch automatically through a small SFINAE ladder:
`operator<< > std::pair > container (recurse) > optional-like > write(crab_os&)`,
with a readable `static_assert` if none applies. `crab::opt` covers
`boost::optional`, `shared_ptr`, `unique_ptr` (and `std::optional` under a
future C++17 build) structurally, without including any of their headers.

## Design decisions

- **No generic `operator<<(crab_os&, const T&)`.** `crab_os`'s 13 stream
  overloads are non-template virtual members that `bool`, `float`, `short`,
  enums and `T*` reach only by promotion/conversion; a `const T&` template
  would be an identity match and silently steal them. The wrappers' hidden
  friend `operator<<` can only ever match the wrapper.
- **`operator<<` is the top dispatch rank**, so an element that could already
  be streamed prints byte-identically to before, by construction. This
  matters because several crab types (e.g. `linear_constraint_t`) have both
  iterators and an `operator<<`.
- **Raw pointers are never auto-dereferenced.** `o << p` keeps printing an
  address; the pointee requires an explicit `crab::opt(p)`. This is what makes
  the optional-like rank unable to change any existing output.
- `std::string` is excluded from container detection (`vector<string>` prints
  `[hi, there]`, not `[[h,i],...]`), and detection uses member `begin()/end()`
  only, so string literals are not ranges.
- C++14 throughout (`make_void` struct per CWG 1558, `priority_tag` ladder,
  no `if constexpr`).

## Changes to existing code

1. `___print___` (debug.hpp) now takes `const ArgTypes &...` instead of
   by-value — output-neutral, and stops deep-copying every `std::string`
   argument at the ~590 `CRAB_ERROR`/`CRAB_WARN` call sites.
2. 26 hand-rolled printing loops that live inside `CRAB_LOG` blocks (or in
   helpers reachable only from them) are converted to the facility, across 20
   files. These sites are invisible to the golden tests (which discard stderr
   and never enable logging), making them the safest possible first users.
   Two debug-only quirks get fixed on the way, both called out here
   deliberately:
   - the 7-copy `Renaming {a;b;} with c;d;}:` cluster (apron, elina,
     sparse_dbm, split_dbm, term_equiv, split_oct, herbrand) was missing the
     opening `{` of the second list in all seven copies; it now prints
     `Renaming {a;b;} with {c;d;}:`.
   - `offset_map_t::write` printed a stray `,` before `}` when the last cell
     of a set was removed; the `print::separator` rewrite fixes it.

   Remaining `CRAB_LOG` loops were left alone on purpose: per-element
   "\t...\n" dumps (a range call is no shorter), the split_oct `rev_map`
   loops (they need the index and a filter with a trailing separator), and
   one site inside dead `#if 0` code.

## Verification

- Golden suite (`tests/run_tests.sh`, default variant, 83 binaries):
  byte-identical before and after every commit.
- The debug output itself was verified, not assumed: stdout+stderr of 19 test
  binaries captured with the relevant `--log` tags before and after the
  conversion. The only difference across ~8200 lines is the intended
  missing-brace fix at the 7 Renaming sites.
- The header was probe-tested standalone (traits, every preset, nesting,
  `vector<string>`, optionals/smart pointers, raw-pointer non-deref,
  const/non-const `write()`, empty ranges) with clang++-14 and g++-10 at
  `-std=c++14 -Wall -Wextra`, both clean.
- apron/elina TUs cannot be compiled locally (no toolchain); their two
  converted hunks are pattern-identical to the five sibling copies that do
  compile and run here. CI with those backends is the real check, as are the
  elina/boxes golden variants.

cc @caballa -- curious what you think of the approach before any further conversion work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
