### PR TITLE
Tag analysis: source-location tags, untainted-by-default reads, and sanitizer intrinsics

### DIFF
--- a/include/crab/domains/region/tags.hpp
+++ b/include/crab/domains/region/tags.hpp
@@ -31,6 +31,76 @@ public:
     return o;
   }
 }; /* end class tag */
+
+// A class with more information about the source of a tag.
+template <typename Number, typename Location>
+class tag_with_info : public indexable {
+  ikos::index_t m_id; // Tag id
+  Location m_src_loc; // location that generated the tag
+  using this_class_t = tag_with_info<Number, Location>;
+  void check_id(Number n) {
+    if (n < 0) {
+      CRAB_ERROR("Cannot use negative numbers for tags");
+    }
+    if (!n.fits_int64()) {
+      CRAB_ERROR("Too large value for a tag");
+    }
+  }
+
+public:
+  tag_with_info(Number n) : m_id(0), m_src_loc(Location()) {
+    check_id(n);
+    m_id = (int64_t)n;
+  }
+  tag_with_info(Number n, Location loc) : m_id(0), m_src_loc(loc) {
+    check_id(n);
+    m_id = (int64_t)n;
+  }
+  // Lexicographic comparison over (m_id, is_valid, location id) so
+  // that operator< is a strict weak order. An invalid location
+  // carries no meaningful id, so it is ordered before any valid one
+  // and compared as id-only otherwise.
+  bool operator<(const this_class_t &as) const {
+    if (m_id != as.m_id) {
+      return m_id < as.m_id;
+    }
+    const bool this_valid = m_src_loc.is_valid();
+    const bool other_valid = as.m_src_loc.is_valid();
+    if (this_valid != other_valid) {
+      return !this_valid;
+    }
+    if (!this_valid) {
+      // both locations are invalid: compare by tag id only
+      return false;
+    }
+    return m_src_loc.get_id() < as.m_src_loc.get_id();
+  }
+  bool operator==(const this_class_t &as) const {
+    if (m_id != as.m_id) {
+      return false;
+    }
+    const bool this_valid = m_src_loc.is_valid();
+    const bool other_valid = as.m_src_loc.is_valid();
+    if (this_valid != other_valid) {
+      return false;
+    }
+    // both invalid locations compare equal (id-only comparison)
+    return !this_valid || (m_src_loc.get_id() == as.m_src_loc.get_id());
+  }
+  virtual ikos::index_t index() const override { return m_id; }
+  void write(crab_os &o) const override {
+    o << "TAG_" << m_id;
+    if (m_src_loc.is_valid()) {
+      o << " [src: " << m_src_loc << "]";
+    } else {
+      o << " [src: <unknown>]";
+    }
+  }
+  friend crab_os &operator<<(crab_os &o, const this_class_t &as) {
+    as.write(o);
+    return o;
+  }
+}; /* end class tag_with_info */
 } // end namespace region_domain_impl
 } // end namespace domains
 } // end namespace crab

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -156,7 +156,7 @@ private:
   using alloc_site_env_t = separate_discrete_domain<variable_t, allocation_site>;
   using allocation_sites = typename alloc_site_env_t::mapped_type;
   // Map variables to sets of tags
-  using tag_t = region_domain_impl::tag<number_t>;
+  using tag_t = region_domain_impl::tag_with_info<number_t, source_location>;
   using tag_env_t = separate_discrete_domain<variable_t, tag_t>;
   using tag_set = typename tag_env_t::mapped_type;
   
@@ -520,11 +520,19 @@ private:
     return m_ghost_var_man.rev_rename_linear_cst(cst, ignore_references);
   }
 
+  tag_set find_tag_or_not(const variable_t &v) const {
+    if (auto tag_val = m_tag_env.find(v)) {
+      return tag_set(*tag_val);
+    } else {
+      return tag_set::bottom();
+    }
+  }
+
   template <class RangeVars>
   void merge_tags(const variable_t &x, RangeVars vars) {
     tag_set tags = tag_set::bottom();
     for (auto const &v : vars) {
-      tags = tags | m_tag_env.at(v);
+      tags = tags | find_tag_or_not(v);
     }
     m_tag_env.set(x, tags);
   }
@@ -975,7 +983,7 @@ public:
     }
     if (crab_domain_params_man::get().region_tag_analysis()) {
       // Region does not contain any tag
-      m_tag_env.set(rgn, tag_env_t::mapped_type::bottom());
+      m_tag_env.set(rgn, tag_set::bottom());
     }
 
     if (!(rgn.get_type().is_unknown_region())) {
@@ -1019,7 +1027,8 @@ public:
       m_rgn_equiv_classes.add(rhs_rgn, lhs_rgn);
     }
     if (crab_domain_params_man::get().region_tag_analysis()) {
-      m_tag_env.set(lhs_rgn, m_tag_env.at(rhs_rgn));
+      m_tag_env.set(lhs_rgn,
+                    find_tag_or_not(rhs_rgn) | find_tag_or_not(lhs_rgn));
     }
 
     if (!is_tracked_region(rhs_rgn, rhs_rgn_info.type_val())) {
@@ -1094,7 +1103,8 @@ public:
       m_rgn_equiv_classes.add(src_rgn, dst_rgn);
     }
     if (crab_domain_params_man::get().region_tag_analysis()) {
-      m_tag_env.set(dst_rgn, m_tag_env.at(src_rgn));
+      m_tag_env.set(dst_rgn,
+                    find_tag_or_not(src_rgn) | find_tag_or_not(dst_rgn));
     }
 
     region_domain_impl::region_info src_rgn_info = m_rgn_env.at(src_rgn);
@@ -1257,7 +1267,7 @@ public:
     }
 
     if (crab_domain_params_man::get().region_tag_analysis()) {
-      m_tag_env.set(res, m_tag_env.at(rgn));
+      m_tag_env.set(res, find_tag_or_not(rgn));
     }
 
     if (!is_tracked_region(rgn)) {
@@ -1506,7 +1516,10 @@ public:
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
         if (val.is_variable()) {
-          m_tag_env.set(rgn, m_tag_env.at(val.get_variable()));
+          m_tag_env.set(rgn, find_tag_or_not(val.get_variable()));
+        } else {
+          // Region does not contain any tag
+          m_tag_env.set(rgn, tag_set::bottom());
         }
       }
 
@@ -1529,8 +1542,8 @@ public:
       }
       if (crab_domain_params_man::get().region_tag_analysis()) {
         if (val.is_variable()) {
-          m_tag_env.set(rgn,
-                        m_tag_env.at(rgn) | m_tag_env.at(val.get_variable()));
+          m_tag_env.set(rgn, find_tag_or_not(rgn) |
+                                 find_tag_or_not(val.get_variable()));
         }
       }
     }
@@ -1593,7 +1606,8 @@ public:
       }
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(ref2, m_tag_env.at(ref1));
+        // merge_tags(ref2, offset.variables());
+        m_tag_env.set(ref2, find_tag_or_not(ref2) | find_tag_or_not(ref1));
       }
 
       if (crab_domain_params_man::get().region_deallocation()) {
@@ -1718,7 +1732,7 @@ public:
       m_base_dom.assign(dst_gvars.get_var(), src_gvars.get_var());
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(int_var, m_tag_env.at(ref_var));
+        m_tag_env.set(int_var, find_tag_or_not(ref_var));
       }
     }
   }
@@ -1745,7 +1759,7 @@ public:
       }
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(ref_var, m_tag_env.at(int_var));
+        m_tag_env.set(ref_var, find_tag_or_not(int_var));
       }
 
       // Update region counting
@@ -1771,7 +1785,7 @@ public:
                        get_or_insert_gvars(y).get_var(),
                        get_or_insert_gvars(z).get_var());
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, m_tag_env.at(y) | m_tag_env.at(z));
+        m_tag_env.set(x, find_tag_or_not(y) | find_tag_or_not(z));
       }
     }
   }
@@ -1784,7 +1798,7 @@ public:
                        get_or_insert_gvars(y).get_var(), k);
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, m_tag_env.at(y));
+        m_tag_env.set(x, find_tag_or_not(y));
       }
     }
   }
@@ -1816,14 +1830,19 @@ public:
       m_base_dom.select(get_or_insert_gvars(lhs).get_var(), b_cond, b_e1, b_e2);
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
+        tag_set cond_tags = tag_set::bottom();
+        // Ignore control dependency
+        // for (auto const &v : cond.variables()) {
+        //   cond_tags = cond_tags | find_tag_or_not(v);
+        // }
         tag_set tags = tag_set::bottom();
         for (auto const &v : e1.variables()) {
-          tags = tags | m_tag_env.at(v);
+          tags = tags | find_tag_or_not(v);
         }
         for (auto const &v : e2.variables()) {
-          tags = tags | m_tag_env.at(v);
+          tags = tags | find_tag_or_not(v);
         }
-        m_tag_env.set(lhs, tags);
+        m_tag_env.set(lhs, tags | cond_tags);
       }
     }
   }
@@ -1905,7 +1924,7 @@ public:
       }
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, tag_env_t::mapped_type::bottom());
+        m_tag_env.set(x, tag_set::bottom());
       }
     }
   }
@@ -1949,7 +1968,7 @@ public:
                        get_or_insert_gvars(src).get_var());
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(dst, m_tag_env.at(src));
+        m_tag_env.set(dst, find_tag_or_not(src));
       }
     }
   }
@@ -1963,7 +1982,7 @@ public:
                        get_or_insert_gvars(z).get_var());
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, m_tag_env.at(y) | m_tag_env.at(z));
+        m_tag_env.set(x, find_tag_or_not(y) | find_tag_or_not(z));
       }
     }
   }
@@ -1976,7 +1995,7 @@ public:
                        get_or_insert_gvars(y).get_var(), z);
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, m_tag_env.at(y));
+        m_tag_env.set(x, find_tag_or_not(y));
       }
     }
   }
@@ -2047,7 +2066,7 @@ public:
                                  is_not_rhs);
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(lhs, m_tag_env.at(rhs));
+        m_tag_env.set(lhs, find_tag_or_not(rhs));
       }
     }
   }
@@ -2067,7 +2086,7 @@ public:
                                    get_or_insert_gvars(z).get_var());
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
-        m_tag_env.set(x, m_tag_env.at(y) | m_tag_env.at(z));
+        m_tag_env.set(x, find_tag_or_not(y) | find_tag_or_not(z));
       }
     }
   }
@@ -2089,7 +2108,7 @@ public:
 
       if (crab_domain_params_man::get().region_tag_analysis()) {
         // it can be improve if we know if cond is true or false
-        m_tag_env.set(lhs, m_tag_env.at(b1) | m_tag_env.at(b2));
+        m_tag_env.set(lhs, find_tag_or_not(b1) | find_tag_or_not(b2));
       }
     }
   }
@@ -2579,11 +2598,10 @@ public:
         error_if_not_rgn(rgn);
         variable_t ref = inputs[1].get_variable();
         error_if_not_ref(ref);
-        tag_t tag(inputs[2].get_constant());
-
+        tag_t tag(inputs[2].get_constant(), rgn.get_debug_info());
         // We ignore ref and merge the tag with the tags already in
         // the region
-        m_tag_env.set(rgn, m_tag_env.at(rgn) | tag_set(tag));
+        m_tag_env.set(rgn, find_tag_or_not(rgn) | tag_set(tag));
       }
     } else if (name == "does_not_have_tag") {
       if (crab_domain_params_man::get().region_tag_analysis()) {
@@ -2596,12 +2614,21 @@ public:
         error_if_not_rgn(rgn);
         variable_t ref = inputs[1].get_variable();
         error_if_not_ref(ref);
+        // This is hack tag since no debug info is provided
         tag_t tag(inputs[2].get_constant());
         variable_t bv = outputs[0];
-        tag_set tags = m_tag_env.at(rgn);
-        if (!(tag_set(tag) <= tags)) {
+        tag_set tags = find_tag_or_not(rgn);
+        bool has_tag = (tag_set(tag) <= tags);
+        if (!has_tag) {
           set_bool_var_to_true(bv);
         } else {
+          CRAB_LOG(
+              "region-tag-report", crab::outs()
+                                       << "[Sink] " << rgn.get_debug_info()
+                                       << "\ntainted source:\n";
+              for (auto const &t
+                   : tags) { crab::outs() << t << ", "; } crab::outs()
+              << ";\n";);
           operator-=(bv);
         }
       }
@@ -2769,7 +2796,7 @@ public:
       return false;
     }
 
-    tag_set tag_set = m_tag_env.at(rgn);
+    tag_set tag_set = find_tag_or_not(rgn);
 
     if (tag_set.is_top()) {
       return false;

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -2488,9 +2488,20 @@ public:
     // add_tag(rgn, ref, TAG)
     //       Add TAG to the set of tags already associated with the
     //       data pointed by ref within rgn.
+    // remove_tag(rgn, ref, TAG)
+    //       Remove TAG from the set of tags associated with the data
+    //       pointed by ref within rgn (sanitizer support). The removal
+    //       only happens if rgn represents at most one concrete
+    //       object; otherwise, the tag is conservatively kept.
     // b := does_not_have_tag(rgn, ref, TAG)
     //       b is true if the data pointed by ref within rgn does
     //       *definitely* not have tag TAG.
+    // move_tag(rgn1, ref1, rgn2, ref2)
+    //       Overwrite the tags of rgn2 with the set of tags
+    //       associated with rgn1 (ref1 and ref2 are ignored).
+    // print_tags(rgn, ref)
+    //       Print the set of tags associated with rgn (for
+    //       debugging).
     //=================================================================//
     auto error_if_not_arity = [&name, &inputs, &outputs](unsigned num_inputs,
                                                          unsigned num_outputs) {
@@ -2631,6 +2642,67 @@ public:
               << ";\n";);
           operator-=(bv);
         }
+      }
+    } else if (name == "remove_tag") {
+      if (crab_domain_params_man::get().region_tag_analysis()) {
+        error_if_not_arity(3, 0);
+        error_if_not_variable(inputs[0]);
+        error_if_not_variable(inputs[1]);
+        error_if_not_constant(inputs[2]);
+        variable_t rgn = inputs[0].get_variable();
+        error_if_not_rgn(rgn);
+        variable_t ref = inputs[1].get_variable();
+        error_if_not_ref(ref);
+        // This is hack tag since no debug info is provided. Tag
+        // membership is index-based so the id suffices for removal.
+        tag_t tag(inputs[2].get_constant());
+        // Removing a tag is a strong update on the region, which is
+        // only sound if the region represents at most one concrete
+        // object. We reuse the same refcount condition as ref_store's
+        // strong updates; otherwise, the tag is conservatively kept.
+        auto rgn_info = m_rgn_env.at(rgn);
+        const small_range &num_refs = rgn_info.refcount_val();
+        if (num_refs.is_zero() || num_refs.is_one()) {
+          tag_set tags = find_tag_or_not(rgn);
+          // Skip top: m_tag_env.set would drop the key, which
+          // find_tag_or_not reads back as untainted.
+          if (!tags.is_top() && !tags.is_bottom()) {
+            m_tag_env.set(rgn, tags - tag);
+          }
+        }
+      }
+    } else if (name == "print_tags") {
+      if (crab_domain_params_man::get().region_tag_analysis()) {
+        error_if_not_arity(2, 0);
+        error_if_not_variable(inputs[0]);
+        error_if_not_variable(inputs[1]);
+        variable_t rgn = inputs[0].get_variable();
+        error_if_not_rgn(rgn);
+        tag_set tags = find_tag_or_not(rgn);
+        crab::outs() << "[Debug] Tags: \n{\n";
+        for (auto const &t : tags) {
+          crab::outs() << "  " << t << " |-> [";
+          // find srcs
+          crab::outs() << "];\n";
+        }
+        crab::outs() << "}\n";
+      }
+    } else if (name == "move_tag") {
+      if (crab_domain_params_man::get().region_tag_analysis()) {
+        error_if_not_arity(4, 0);
+        error_if_not_variable(inputs[0]);
+        error_if_not_variable(inputs[1]);
+        error_if_not_variable(inputs[2]);
+        error_if_not_variable(inputs[3]);
+        variable_t rgn1 = inputs[0].get_variable();
+        error_if_not_rgn(rgn1);
+        variable_t ref1 = inputs[1].get_variable();
+        error_if_not_ref(ref1);
+        variable_t rgn2 = inputs[2].get_variable();
+        error_if_not_rgn(rgn2);
+        variable_t ref2 = inputs[3].get_variable();
+        error_if_not_ref(ref2);
+        m_tag_env.set(rgn2, find_tag_or_not(rgn1));
       }
     } else if (name == "is_dereferenceable") {
       if (crab_domain_params_man::get().region_is_dereferenceable()) {

--- a/include/crab/domains/separate_domains.hpp
+++ b/include/crab/domains/separate_domains.hpp
@@ -688,6 +688,12 @@ public:
     return *this;
   }
 
+  // return null if k is not found
+  const mapped_type* find(const Key &k) const {
+    assert(!is_bottom());
+    return m_tree.find(k);
+  }
+
   mapped_type at(const Key &k) const {
     if (is_bottom()) {
       CRAB_ERROR("separate_discrete_domain::at is undefined on bottom");

--- a/include/crab/support/debug.hpp
+++ b/include/crab/support/debug.hpp
@@ -76,4 +76,31 @@ void CrabEnableWarningMsg(bool b);
 extern bool CrabSanityCheckFlag;
 void CrabEnableSanityChecks(bool b);
 
+class source_location {
+private:
+  std::string m_filename;
+  unsigned m_line;
+  unsigned m_column;
+  unsigned m_id;
+  bool m_valid;
+
+public:
+  // Constructors
+  source_location();
+  source_location(const std::string &filename, unsigned line, unsigned column, unsigned id);
+
+  // Default copy constructor and assignment operator
+  source_location(const source_location &) = default;
+  source_location &operator=(const source_location &) = default;
+  bool is_valid() const { return m_valid; }
+  unsigned get_id() const { return m_id; }
+
+  // Output
+  void write(crab_os &o) const;
+  friend crab_os &operator<<(crab_os &o, const source_location &loc) {
+    loc.write(o);
+    return o;
+  }
+};
+
 } // end namespace crab

--- a/include/crab/types/variable.hpp
+++ b/include/crab/types/variable.hpp
@@ -268,6 +268,7 @@ public:
 private:
   VariableName _n;
   variable_type m_ty;
+  boost::optional<source_location> m_loc;
 
 public:
   /* ========== Begin internal API  ============= */
@@ -320,6 +321,25 @@ public:
   }
 
   void dump(crab::crab_os &o) const { o << _n << ":" << get_type(); }
+
+  void set_debug_info(const source_location &loc) {
+    m_loc = loc;
+  }
+
+  source_location get_debug_info() const {
+    if (m_loc) {
+      return *m_loc;
+    } else {
+      return source_location();
+    }
+  }
+
+  void dump_with_debug_info(crab::crab_os &o) const {
+    o << _n << ":" << get_type();
+    if (m_loc) {
+      o << " [" << *m_loc << "]";
+    }
+  }
 
   friend crab::crab_os &operator<<(crab::crab_os &o,
                                    const variable<Number, VariableName> &v) {

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -41,4 +41,27 @@ crab_os &get_msg_stream(bool timestamp) {
   }
   return *result;
 }
+
+source_location::source_location()
+    : m_filename(""), m_line(0), m_column(0), m_id(0), m_valid(false) {}
+
+source_location::source_location(const std::string &filename, unsigned line,
+                                 unsigned column, unsigned id)
+    : m_filename(filename), m_line(line), m_column(column), m_id(id),
+      m_valid(true) {}
+
+void source_location::write(crab_os &o) const {
+  if (!m_valid) {
+    o << "<unknown>";
+    return;
+  }
+
+  o << m_filename;
+  if (m_line > 0) {
+    o << ":" << m_line;
+    if (m_column > 0) {
+      o << ":" << m_column;
+    }
+  }
+}
 } // namespace crab

--- a/tests/domains/region/region-8.cc
+++ b/tests/domains/region/region-8.cc
@@ -13,10 +13,6 @@ std::unique_ptr<z_cfg_t> cfg1(variable_factory_t &vfac) {
   /*
    int v1,v2,v3;
 
-   add_tag(&v1, TAG_1)
-   add_tag(&v2, TAG_2)
-   add_tag(&v3, TAG_3)
-
    int *i = &v1;
    int *x = &v2;
    int *y = &v3;
@@ -24,6 +20,12 @@ std::unique_ptr<z_cfg_t> cfg1(variable_factory_t &vfac) {
    *i := 0;
    *x := 1;
    *y := 0;
+
+   // A strong store of a constant clears the tags of the stored
+   // region, so the tags are added after the initialization.
+   add_tag(&v1, TAG_1)
+   add_tag(&v2, TAG_2)
+   add_tag(&v3, TAG_3)
 
     while(*i <= 99) {
      *x = *x + *y;
@@ -88,15 +90,17 @@ std::unique_ptr<z_cfg_t> cfg1(variable_factory_t &vfac) {
   entry.make_ref(i, mem1, size4, as_man.mk_tag());
   entry.make_ref(x, mem2, size4, as_man.mk_tag());
   entry.make_ref(y, mem3, size4, as_man.mk_tag());
-  entry.intrinsic("add_tag",{},{mem1, i, one32});
-  entry.intrinsic("add_tag",{},{mem2, x, two32});
-  entry.intrinsic("add_tag",{},{mem3, y, three32});    
   //// *i := 0;
   entry.store_to_ref(i, mem1, zero32);
   //// *x := 1;
   entry.store_to_ref(x, mem2, one32);
   //// *y := 0;
   entry.store_to_ref(y, mem3, zero32);
+  //// A strong store of a constant clears the tags of the stored
+  //// region, so the tags are added after the initialization.
+  entry.intrinsic("add_tag",{},{mem1, i, one32});
+  entry.intrinsic("add_tag",{},{mem2, x, two32});
+  entry.intrinsic("add_tag",{},{mem3, y, three32});
   //// assume(*i <= 99);
   bb1_t.load_from_ref(deref_i, i, mem1);
   bb1_t.assume(deref_i <= 99);
@@ -137,6 +141,84 @@ std::unique_ptr<z_cfg_t> cfg1(variable_factory_t &vfac) {
   return cfg;
 }
 
+/* Test for remove_tag (sanitizer support) */
+std::unique_ptr<z_cfg_t> cfg2(variable_factory_t &vfac) {
+
+  /*
+   int v1,v2;
+
+   int *p = &v1;         // only reference to &v1: strong updates allowed
+   add_tag(&v1, TAG_1)
+   add_tag(&v1, TAG_2)
+   remove_tag(&v1, TAG_1)
+
+   // TAG_1 was removed by a strong update; TAG_2 remains
+   assert(does_not_have_tag(&v1, TAG_1));  // OK
+   assert(does_not_have_tag(&v1, TAG_2));  // FAIL
+
+   int *q1 = &v2;
+   int *q2 = &v2;        // two references: no strong update on &v2
+   add_tag(&v2, TAG_3)
+   remove_tag(&v2, TAG_3)
+
+   // refcount > 1 so the tag is conservatively kept
+   assert(does_not_have_tag(&v2, TAG_3));  // FAIL
+   */
+
+  // === Define program variables
+  z_var p(vfac["p"], crab::REF_TYPE);
+  z_var q1(vfac["q1"], crab::REF_TYPE);
+  z_var q2(vfac["q2"], crab::REF_TYPE);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  // === Define memory regions
+  z_var mem1(vfac["region_0"], crab::REG_INT_TYPE, 32);
+  z_var mem2(vfac["region_1"], crab::REG_INT_TYPE, 32);
+  // === Create allocation sites
+  crab::tag_manager as_man;
+  // === Create empty CFG
+  auto cfg = std::make_unique<z_cfg_t>("entry", "ret");
+  // === Adding CFG blocks
+  BB(cfg, entry);
+  BB(cfg, ret);
+  // === Adding CFG edges
+  entry.add_succ(ret);
+
+  // === Adding statements
+
+  z_var_or_cst_t one32(z_number(1), crab::variable_type(crab::INT_TYPE, 32));
+  z_var_or_cst_t two32(z_number(2), crab::variable_type(crab::INT_TYPE, 32));
+  z_var_or_cst_t three32(z_number(3), crab::variable_type(crab::INT_TYPE, 32));
+  z_var_or_cst_t size4(z_number(4), crab::variable_type(crab::INT_TYPE, 32));
+
+  // Intialization of memory regions
+  entry.region_init(mem1);
+  entry.region_init(mem2);
+
+  //// Create references
+  entry.make_ref(p, mem1, size4, as_man.mk_tag());
+  //// mem1 has a single reference: remove_tag performs a strong update
+  entry.intrinsic("add_tag",{},{mem1, p, one32});
+  entry.intrinsic("add_tag",{},{mem1, p, two32});
+  entry.intrinsic("remove_tag",{},{mem1, p, one32});
+
+  //// mem2 has more than one reference: remove_tag keeps the tag
+  entry.make_ref(q1, mem2, size4, as_man.mk_tag());
+  entry.make_ref(q2, mem2, size4, as_man.mk_tag());
+  entry.intrinsic("add_tag",{},{mem2, q1, three32});
+  entry.intrinsic("remove_tag",{},{mem2, q1, three32});
+
+  ret.intrinsic("does_not_have_tag",{b1},{mem1, p, one32});
+  // EXPECTED: OK (TAG_1 was removed)
+  ret.bool_assert(b1);
+  ret.intrinsic("does_not_have_tag",{b1},{mem1, p, two32});
+  // EXPECTED: FAIL (TAG_2 remains)
+  ret.bool_assert(b1);
+  ret.intrinsic("does_not_have_tag",{b1},{mem2, q1, three32});
+  // EXPECTED: FAIL (refcount > 1 so TAG_3 is conservatively kept)
+  ret.bool_assert(b1);
+  return cfg;
+}
+
 int main(int argc, char **argv) {
   region_domain_params p(true/*allocation_sites*/,
 			 true/*deallocation*/,
@@ -150,12 +232,21 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  variable_factory_t vfac;
+  {
+    variable_factory_t vfac;
+    auto p1 = cfg1(vfac);
+    crab::outs() << *p1 << "\n";
+    z_rgn_bool_int_t init;
+    run_and_check(p1, init, stats_enabled, run_config().with_widening(2));
+  }
 
-  auto p1 = cfg1(vfac);
-  crab::outs() << *p1 << "\n";
-  z_rgn_bool_int_t init;
-  run_and_check(p1, init, stats_enabled, run_config().with_widening(2));
+  {
+    variable_factory_t vfac;
+    auto p2 = cfg2(vfac);
+    crab::outs() << *p2 << "\n";
+    z_rgn_bool_int_t init;
+    run_and_check(p2, init, stats_enabled, run_config().with_widening(2));
+  }
 
   return 0;
 }

--- a/tests/expected_results.out
+++ b/tests/expected_results.out
@@ -2461,12 +2461,12 @@ entry:
   i := make_ref(region_0:region(int),4,as_0);
   x := make_ref(region_1:region(int),4,as_1);
   y := make_ref(region_2:region(int),4,as_2);
-  crab_intrinsic(add_tag,region_0:region(int),i:ref,1:int32);
-  crab_intrinsic(add_tag,region_1:region(int),x:ref,2:int32);
-  crab_intrinsic(add_tag,region_2:region(int),y:ref,3:int32);
   store_to_ref(region_0:region(int),i:ref,0:int32);
   store_to_ref(region_1:region(int),x:ref,1:int32);
   store_to_ref(region_2:region(int),y:ref,0:int32);
+  crab_intrinsic(add_tag,region_0:region(int),i:ref,1:int32);
+  crab_intrinsic(add_tag,region_1:region(int),x:ref,2:int32);
+  crab_intrinsic(add_tag,region_2:region(int),y:ref,3:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
@@ -2513,6 +2513,35 @@ user-defined assertion checker
 4  Number of total safe checks
 0  Number of total error checks
 1  Number of total warning checks
+0  Number of total unreachable checks
+
+entry:
+  region_init(region_0:region(int));
+  region_init(region_1:region(int));
+  p := make_ref(region_0:region(int),4,as_0);
+  crab_intrinsic(add_tag,region_0:region(int),p:ref,1:int32);
+  crab_intrinsic(add_tag,region_0:region(int),p:ref,2:int32);
+  crab_intrinsic(remove_tag,region_0:region(int),p:ref,1:int32);
+  q1 := make_ref(region_1:region(int),4,as_1);
+  q2 := make_ref(region_1:region(int),4,as_2);
+  crab_intrinsic(add_tag,region_1:region(int),q1:ref,3:int32);
+  crab_intrinsic(remove_tag,region_1:region(int),q1:ref,3:int32);
+  goto ret;
+ret:
+  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int),p:ref,1:int32);
+  assert(b1);
+  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int),p:ref,2:int32);
+  assert(b1);
+  b1 = crab_intrinsic(does_not_have_tag,region_1:region(int),q1:ref,3:int32);
+  assert(b1);
+
+
+Invariants using Region
+Abstract trace: entry ret
+user-defined assertion checker
+1  Number of total safe checks
+0  Number of total error checks
+2  Number of total warning checks
 0  Number of total unreachable checks
 
 === End ./test-bin/region-8 ===


### PR DESCRIPTION
This PR extends the region domain's tag (taint) analysis in three
independent, stacked steps.

### 1. Source locations on variables (`3b09ee88`)

Adds `crab::source_location` (`support/debug.hpp` + `lib/debug.cpp`) and an
optional debug-info slot on `variable` (`set_debug_info`/`get_debug_info`).
A frontend can stamp a variable with the program point it came from; unset
locations cost one empty `boost::optional`.

### 2. Tags that carry their source, and untainted-by-default (`c79be3d3`)

- `region_domain_impl::tag_with_info<Number, Location>`: a tag that
  remembers the location that created it, printed as
  `TAG_<id> [src: file:line:col]`. Ordering is a strict weak order over
  `(id, location-validity, location id)`; membership stays keyed by id, so
  frontends that build query tags without debug info keep working.
- The region domain's tag type becomes `tag_with_info`; `add_tag` stamps
  the new tag with the region variable's debug info, and a failing
  `does_not_have_tag` reports the offending sources on the log channel
  `region-tag-report` (`[Sink] <loc>` + the tag set).
- **Semantic change — absent means untainted**: tag reads go through a new
  `find_tag_or_not` (absent entry = bottom = no tags) instead of
  `m_tag_env.at` (absent = top = any tag). 27 read sites converted. This
  matches the analysis' initialization ("everything starts clean") and
  makes warnings meaningful for never-tainted regions. Related rule
  adjustments: `region_copy`/`region_cast`/`ref_gep` now UNION tags into
  the destination instead of overwriting, and a strong `ref_store` of a
  non-variable (constant) clears the region's tags.
- `separate_discrete_domain::find` (pointer-or-null lookup) supports the
  above without materializing top for absent keys.

### 3. New intrinsics: `move_tag`, `print_tags`, `remove_tag` (`3fb863e2`)

- `move_tag(rgn1, ref1, rgn2, ref2)`: `tags(rgn2) := tags(rgn1)` (used by
  clam to model memcpy-style region copies).
- `print_tags(rgn, ref)`: debug dump.
- `remove_tag(rgn, ref, TAG)`: sanitizer support. Removing a tag is a
  strong update on a summarized region, so it only happens when the
  region's reference count is at most one — the same condition `ref_store`
  uses for strong updates — and is a sound no-op otherwise. Top/bottom tag
  sets are left untouched (setting a top value would drop the map entry,
  which now reads back as untainted).

### Tests (`8739141e`)

`tests/domains/region/region-8.cc`: with untainted-by-default semantics the
original ordering (tags added before the initializing stores) let a strong
constant store wipe every tag, making all checks pass vacuously; the tags
are now added after initialization and the test yields its annotated
4 safe + 1 warning. A second CFG covers `remove_tag`: strong-update removal
proves clean, an unremoved tag still warns, and a region with refcount > 1
keeps its tag (1 safe + 2 warnings). Verified by building and running the
test with clang-14; `[Sink]` reporting checked via `--log=region-tag-report`.

Deliberately NOT included: any implicit-flow machinery, and no change to
`discrete_domain::operator<=` (the existing definition already handles
bottom/top correctly).
