### PR TITLE
Add const_statement_visitor and migrate read-only visitors

### DIFF
--- a/include/crab/analysis/abs_transformer_api.hpp
+++ b/include/crab/analysis/abs_transformer_api.hpp
@@ -43,8 +43,8 @@ namespace analyzer {
  **/
 template <typename BasicBlockLabel, typename Number, typename VariableName>
 class abs_transformer_api
-    : public crab::cfg::statement_visitor<BasicBlockLabel, Number,
-                                          VariableName> {
+    : public crab::cfg::const_statement_visitor<BasicBlockLabel, Number,
+                                                VariableName> {
 public:
   using number_t = Number;
   using varname_t = VariableName;
@@ -118,74 +118,74 @@ public:
       crab::cfg::bool_assert_stmt<bb_label_t, number_t, varname_t>;
 
 protected:
-  virtual void exec(havoc_t &) {}
-  virtual void exec(unreach_t &) {}
-  virtual void exec(bin_op_t &) {}
-  virtual void exec(assign_t &) {}
-  virtual void exec(assume_t &) {}
-  virtual void exec(select_t &) {}
-  virtual void exec(assert_t &) {}
-  virtual void exec(int_cast_t &) {}
-  virtual void exec(callsite_t &) {}
-  virtual void exec(intrinsic_t &) {}
-  virtual void exec(arr_init_t &) {}
-  virtual void exec(arr_store_t &) {}
-  virtual void exec(arr_load_t &) {}
-  virtual void exec(arr_assign_t &) {}
-  virtual void exec(region_init_t &) {}
-  virtual void exec(region_copy_t &) {}
-  virtual void exec(region_cast_t &) {}  
-  virtual void exec(make_ref_t &) {}
-  virtual void exec(remove_ref_t &) {}  
-  virtual void exec(load_from_ref_t &) {}
-  virtual void exec(store_to_ref_t &) {}
-  virtual void exec(gep_ref_t &) {}
-  virtual void exec(assume_ref_t &) {}
-  virtual void exec(assert_ref_t &) {}
-  virtual void exec(select_ref_t &) {}
-  virtual void exec(int_to_ref_t &) {}
-  virtual void exec(ref_to_int_t &) {}
-  virtual void exec(bool_bin_op_t &) {}
-  virtual void exec(bool_assign_cst_t &) {}
-  virtual void exec(bool_assign_var_t &) {}
-  virtual void exec(bool_assume_t &) {}
-  virtual void exec(bool_select_t &) {}
-  virtual void exec(bool_assert_t &) {}
+  virtual void exec(const havoc_t &) {}
+  virtual void exec(const unreach_t &) {}
+  virtual void exec(const bin_op_t &) {}
+  virtual void exec(const assign_t &) {}
+  virtual void exec(const assume_t &) {}
+  virtual void exec(const select_t &) {}
+  virtual void exec(const assert_t &) {}
+  virtual void exec(const int_cast_t &) {}
+  virtual void exec(const callsite_t &) {}
+  virtual void exec(const intrinsic_t &) {}
+  virtual void exec(const arr_init_t &) {}
+  virtual void exec(const arr_store_t &) {}
+  virtual void exec(const arr_load_t &) {}
+  virtual void exec(const arr_assign_t &) {}
+  virtual void exec(const region_init_t &) {}
+  virtual void exec(const region_copy_t &) {}
+  virtual void exec(const region_cast_t &) {}  
+  virtual void exec(const make_ref_t &) {}
+  virtual void exec(const remove_ref_t &) {}  
+  virtual void exec(const load_from_ref_t &) {}
+  virtual void exec(const store_to_ref_t &) {}
+  virtual void exec(const gep_ref_t &) {}
+  virtual void exec(const assume_ref_t &) {}
+  virtual void exec(const assert_ref_t &) {}
+  virtual void exec(const select_ref_t &) {}
+  virtual void exec(const int_to_ref_t &) {}
+  virtual void exec(const ref_to_int_t &) {}
+  virtual void exec(const bool_bin_op_t &) {}
+  virtual void exec(const bool_assign_cst_t &) {}
+  virtual void exec(const bool_assign_var_t &) {}
+  virtual void exec(const bool_assume_t &) {}
+  virtual void exec(const bool_select_t &) {}
+  virtual void exec(const bool_assert_t &) {}
 
 public: /* visitor api */
-  virtual void visit(havoc_t &s) override { exec(s); }
-  virtual void visit(unreach_t &s) override { exec(s); }
-  virtual void visit(bin_op_t &s) override { exec(s); }
-  virtual void visit(assign_t &s) override { exec(s); }
-  virtual void visit(assume_t &s) override { exec(s); }
-  virtual void visit(select_t &s) override { exec(s); }
-  virtual void visit(assert_t &s) override { exec(s); }
-  virtual void visit(int_cast_t &s) override { exec(s); }
-  virtual void visit(callsite_t &s) override { exec(s); }
-  virtual void visit(intrinsic_t &s) override { exec(s); }
-  virtual void visit(arr_init_t &s) override { exec(s); }
-  virtual void visit(arr_store_t &s) override { exec(s); }
-  virtual void visit(arr_load_t &s) override { exec(s); }
-  virtual void visit(arr_assign_t &s) override { exec(s); }
-  virtual void visit(region_init_t &s) override { exec(s); }
-  virtual void visit(region_copy_t &s) override { exec(s); }
-  virtual void visit(region_cast_t &s) override { exec(s); }  
-  virtual void visit(make_ref_t &s) override { exec(s); }
-  virtual void visit(remove_ref_t &s) override { exec(s); }  
-  virtual void visit(load_from_ref_t &s) override { exec(s); }
-  virtual void visit(store_to_ref_t &s) override { exec(s); }
-  virtual void visit(gep_ref_t &s) override { exec(s); }
-  virtual void visit(assume_ref_t &s) override { exec(s); }
-  virtual void visit(assert_ref_t &s) override { exec(s); }
-  virtual void visit(select_ref_t &s) override { exec(s); }
-  virtual void visit(ref_to_int_t &s) override { exec(s); }
-  virtual void visit(int_to_ref_t &s) override { exec(s); }
-  virtual void visit(bool_bin_op_t &s) override { exec(s); }
-  virtual void visit(bool_assign_cst_t &s) override { exec(s); }
-  virtual void visit(bool_assign_var_t &s) override { exec(s); }
-  virtual void visit(bool_assume_t &s) override { exec(s); }
-  virtual void visit(bool_select_t &s) override { exec(s); }
-  virtual void visit(bool_assert_t &s) override { exec(s); }
+  virtual void visit(const havoc_t &s) override { exec(s); }
+  virtual void visit(const unreach_t &s) override { exec(s); }
+  virtual void visit(const bin_op_t &s) override { exec(s); }
+  virtual void visit(const assign_t &s) override { exec(s); }
+  virtual void visit(const assume_t &s) override { exec(s); }
+  virtual void visit(const select_t &s) override { exec(s); }
+  virtual void visit(const assert_t &s) override { exec(s); }
+  virtual void visit(const int_cast_t &s) override { exec(s); }
+  virtual void visit(const callsite_t &s) override { exec(s); }
+  virtual void visit(const intrinsic_t &s) override { exec(s); }
+  virtual void visit(const arr_init_t &s) override { exec(s); }
+  virtual void visit(const arr_store_t &s) override { exec(s); }
+  virtual void visit(const arr_load_t &s) override { exec(s); }
+  virtual void visit(const arr_assign_t &s) override { exec(s); }
+  virtual void visit(const region_init_t &s) override { exec(s); }
+  virtual void visit(const region_copy_t &s) override { exec(s); }
+  virtual void visit(const region_cast_t &s) override { exec(s); }  
+  virtual void visit(const make_ref_t &s) override { exec(s); }
+  virtual void visit(const remove_ref_t &s) override { exec(s); }  
+  virtual void visit(const load_from_ref_t &s) override { exec(s); }
+  virtual void visit(const store_to_ref_t &s) override { exec(s); }
+  virtual void visit(const gep_ref_t &s) override { exec(s); }
+  virtual void visit(const assume_ref_t &s) override { exec(s); }
+  virtual void visit(const assert_ref_t &s) override { exec(s); }
+  virtual void visit(const select_ref_t &s) override { exec(s); }
+  virtual void visit(const ref_to_int_t &s) override { exec(s); }
+  virtual void visit(const int_to_ref_t &s) override { exec(s); }
+  virtual void visit(const bool_bin_op_t &s) override { exec(s); }
+  virtual void visit(const bool_assign_cst_t &s) override { exec(s); }
+  virtual void visit(const bool_assign_var_t &s) override { exec(s); }
+  virtual void visit(const bool_assume_t &s) override { exec(s); }
+  virtual void visit(const bool_select_t &s) override { exec(s); }
+  virtual void visit(const bool_assert_t &s) override { exec(s); }
 };
 
 /**

--- a/include/crab/analysis/bwd_abs_transformers.hpp
+++ b/include/crab/analysis/bwd_abs_transformers.hpp
@@ -111,7 +111,7 @@ public:
 
   abs_dom_t preconditions() { return m_pre; }
 
-  virtual void exec(bin_op_t &stmt) override {
+  virtual void exec(const bin_op_t &stmt) override {
     auto op = conv_op<domains::arith_operation_t>(stmt.op());
     if (!op || op >= domains::OP_UDIV) {
       // ignore UDIV, SREM, UREM
@@ -153,7 +153,7 @@ public:
   //     x := e2;
   //     goto post;
   //   post: ....
-  virtual void exec(select_t &stmt) override {
+  virtual void exec(const select_t &stmt) override {
     abs_dom_t old_pre = get_forward_invariant(&stmt);
 
     // -- one of the two branches is false
@@ -186,7 +186,7 @@ public:
   }
 
   // x := e
-  virtual void exec(assign_t &stmt) override {
+  virtual void exec(const assign_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
 
     CRAB_LOG("backward-tr", auto rhs = stmt.rhs();
@@ -200,7 +200,7 @@ public:
 
   // assume(c)
   // the precondition must contain c so forward and backward are the same.
-  virtual void exec(assume_t &stmt) override {
+  virtual void exec(const assume_t &stmt) override {
     CRAB_LOG("backward-tr", crab::outs() << "** " << stmt << "\n"
                                          << "\tPOST=" << m_pre << "\n");
     m_pre += stmt.constraint();
@@ -208,7 +208,7 @@ public:
   }
 
   // assert(c)
-  virtual void exec(assert_t &stmt) override {
+  virtual void exec(const assert_t &stmt) override {
     if (!m_ignore_assert) {
       CRAB_LOG("backward-tr", crab::outs() << "** " << stmt << "\n"
                                            << "\tPOST=" << m_pre << "\n");
@@ -233,17 +233,17 @@ public:
   }
 
   // similar to assume(false)
-  virtual void exec(unreach_t &stmt) override {
+  virtual void exec(const unreach_t &stmt) override {
     m_pre.set_to_bottom();
   }
 
   // x := *
   // x can be anything before the assignment
-  virtual void exec(havoc_t &stmt) override {
+  virtual void exec(const havoc_t &stmt) override {
     m_pre -= stmt.get_variable();
   }
 
-  virtual void exec(int_cast_t &stmt) override {
+  virtual void exec(const int_cast_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
     CRAB_LOG("backward-tr", crab::outs() << "** " << stmt << "\n"
                                          << "\tPOST=" << m_pre << "\n");
@@ -251,23 +251,23 @@ public:
     CRAB_LOG("backward-tr", crab::outs() << "\tPRE=" << m_pre << "\n");
   }
 
-  virtual void exec(bool_assign_cst_t &stmt) override {
+  virtual void exec(const bool_assign_cst_t &stmt) override {
     m_pre -= stmt.lhs();
   }
   
-  virtual void exec(bool_assign_var_t &stmt) override {
+  virtual void exec(const bool_assign_var_t &stmt) override {
     m_pre -= stmt.lhs();
   }
   
-  virtual void exec(bool_bin_op_t &stmt) override {
+  virtual void exec(const bool_bin_op_t &stmt) override {
     m_pre -= stmt.lhs();
   }
   
-  virtual void exec(bool_select_t &stmt) override {
+  virtual void exec(const bool_select_t &stmt) override {
     m_pre -= stmt.lhs();
   }
 
-  virtual void exec(bool_assume_t &stmt) override {
+  virtual void exec(const bool_assume_t &stmt) override {
     // same as forward
     CRAB_LOG("backward-tr", crab::outs() << "** " << stmt << "\n"
                                          << "\tPOST=" << m_pre << "\n");
@@ -275,7 +275,7 @@ public:
     CRAB_LOG("backward-tr", crab::outs() << "\tPRE=" << m_pre << "\n");
   }
 
-  virtual void exec(bool_assert_t &stmt) override {
+  virtual void exec(const bool_assert_t &stmt) override {
     if (!m_ignore_assert) {
       CRAB_LOG("backward-tr", crab::outs() << "** " << stmt << "\n"
                                            << "\tPOST=" << m_pre << "\n");
@@ -291,7 +291,7 @@ public:
     }
   }
 
-  virtual void exec(arr_init_t &stmt) override {
+  virtual void exec(const arr_init_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
 
     CRAB_LOG("backward-tr", crab::outs()
@@ -304,7 +304,7 @@ public:
     CRAB_LOG("backward-tr", crab::outs() << "\tPRE=" << m_pre << "\n");
   }
 
-  virtual void exec(arr_load_t &stmt) override {
+  virtual void exec(const arr_load_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
 
     CRAB_LOG("backward-tr", crab::outs()
@@ -316,7 +316,7 @@ public:
     CRAB_LOG("backward-tr", crab::outs() << "\tPRE=" << m_pre << "\n");
   }
 
-  virtual void exec(arr_store_t &stmt) override {
+  virtual void exec(const arr_store_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
     CRAB_LOG("backward-tr", crab::outs()
                                 << "** " << stmt << "\n"
@@ -335,7 +335,7 @@ public:
     CRAB_LOG("backward-tr", crab::outs() << "\tPRE=" << m_pre << "\n");
   }
 
-  virtual void exec(arr_assign_t &stmt) override {
+  virtual void exec(const arr_assign_t &stmt) override {
     abs_dom_t invariant = get_forward_invariant(&stmt);
     CRAB_LOG("backward-tr", crab::outs()
                                 << "** " << stmt << "\n"
@@ -346,29 +346,29 @@ public:
   }
 
   // NOT IMPLEMENTED
-  virtual void exec(region_init_t &stmt) override {}
-  virtual void exec(region_copy_t &stmt) override {}
-  virtual void exec(region_cast_t &stmt) override {}  
-  virtual void exec(make_ref_t &stmt) override {}
-  virtual void exec(remove_ref_t &stmt) override {}  
-  virtual void exec(load_from_ref_t &stmt) override {}
-  virtual void exec(store_to_ref_t &stmt) override {}
-  virtual void exec(gep_ref_t &stmt) override {}
-  virtual void exec(assume_ref_t &stmt) override {}
-  virtual void exec(assert_ref_t &stmt) override {}
-  virtual void exec(select_ref_t &stmt) override {}
-  virtual void exec(int_to_ref_t &stmt) override {}
-  virtual void exec(ref_to_int_t &stmt) override {}
+  virtual void exec(const region_init_t &stmt) override {}
+  virtual void exec(const region_copy_t &stmt) override {}
+  virtual void exec(const region_cast_t &stmt) override {}  
+  virtual void exec(const make_ref_t &stmt) override {}
+  virtual void exec(const remove_ref_t &stmt) override {}  
+  virtual void exec(const load_from_ref_t &stmt) override {}
+  virtual void exec(const store_to_ref_t &stmt) override {}
+  virtual void exec(const gep_ref_t &stmt) override {}
+  virtual void exec(const assume_ref_t &stmt) override {}
+  virtual void exec(const assert_ref_t &stmt) override {}
+  virtual void exec(const select_ref_t &stmt) override {}
+  virtual void exec(const int_to_ref_t &stmt) override {}
+  virtual void exec(const ref_to_int_t &stmt) override {}
 
   /// -- Call and return can be redefined by derived classes
 
-  virtual void exec(callsite_t &cs) override {
+  virtual void exec(const callsite_t &cs) override {
     for (const variable_t &vt : cs.get_lhs()) {
       m_pre -= vt;
     }
   }
 
-  virtual void exec(intrinsic_t &cs) override {
+  virtual void exec(const intrinsic_t &cs) override {
     abs_dom_t invariant = get_forward_invariant(&cs);
     m_pre.backward_intrinsic(cs.get_intrinsic_name(), cs.get_args(),
                              cs.get_lhs(), std::move(invariant));

--- a/include/crab/analysis/bwd_np_analyzer.hpp
+++ b/include/crab/analysis/bwd_np_analyzer.hpp
@@ -65,7 +65,7 @@ class necessary_preconditions_fixpoint_iterator
     // rebuild local invariants that hold at each program point.
     abs_fwd_tr_t F(invariant);
     pp_abstract_map_t pp_invariants;
-    for (auto &s : boost::make_iterator_range(bb.begin(), bb.end())) {
+    for (auto const &s : boost::make_iterator_range(bb.begin(), bb.end())) {
       auto inv = F.get_abs_value();
       pp_invariants.insert(std::make_pair(&s, inv));
       CRAB_LOG("backward-fixpoint", crab::outs()
@@ -80,7 +80,7 @@ class necessary_preconditions_fixpoint_iterator
 
     // compute precondition at the entry of the block
     abs_bwd_tr_t B(std::move(precond), &pp_invariants, m_good_states);
-    for (auto &s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
+    for (auto const &s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
       s.accept(&B);
     }
     precond = std::move(B.preconditions());

--- a/include/crab/analysis/dataflow/assertion_crawler.hpp
+++ b/include/crab/analysis/dataflow/assertion_crawler.hpp
@@ -41,9 +41,9 @@ private:
   // unique identifier for the assert needed for being used as key
   ikos::index_t m_id;
   // the assert statement
-  statement_t *m_assert;
+  const statement_t *m_assert;
 public:
-  assert_wrapper(ikos::index_t id, statement_t *assert)
+  assert_wrapper(ikos::index_t id, const statement_t *assert)
     : m_id(id), m_assert(assert) {
     if (!m_assert) {
       CRAB_ERROR("assert_wrapper with null assert statement");
@@ -53,9 +53,6 @@ public:
     }
   }
   
-  statement_t &get() {
-    return *m_assert;
-  }
   const statement_t &get() const {
     return *m_assert;
   }
@@ -286,7 +283,8 @@ public:
   using assertion_crawler_domain_t = assertion_crawler_impl::assertion_crawler_domain<CFG>;
   using var_dom_t = typename assertion_crawler_domain_t::var_dom_t;  
   using assert_wrapper_t = assertion_crawler_impl::assert_wrapper<CFG>;  
-  using assert_map_t = typename std::unordered_map<statement_t *, assert_wrapper_t>;
+  using assert_map_t =
+      typename std::unordered_map<const statement_t *, assert_wrapper_t>;
   // control-dependency graph: map a CFG block to the set of blocks
   // which control-dependent on it.
   using cdg_t = std::unordered_map<basic_block_label_t, std::vector<basic_block_label_t>>;
@@ -300,8 +298,11 @@ public:
   ////============================================================////
   //            Propagate data/control dependencies
   ////============================================================////  
-  class transfer_function : public statement_visitor<basic_block_label_t, number_t, varname_t> {
-    using visitor_t = statement_visitor<basic_block_label_t, number_t, varname_t>; 
+  class transfer_function
+      : public const_statement_visitor<basic_block_label_t, number_t,
+                                      varname_t> {
+    using visitor_t =
+        const_statement_visitor<basic_block_label_t, number_t, varname_t>;
     using bin_op_t = typename visitor_t::bin_op_t;
     using assign_t = typename visitor_t::assign_t;
     using assume_t = typename visitor_t::assume_t;
@@ -469,7 +470,7 @@ public:
     summary_map_t &m_summaries;
     bool m_opt_ignore_region_offset;
     
-    inline void process_assertion(statement_t &s) {
+    inline void process_assertion(const statement_t &s) {
       assert(s.is_assert() || s.is_ref_assert() || s.is_bool_assert());
       
       auto it = m_assert_map.find(&s);
@@ -491,7 +492,7 @@ public:
                                              << "\tAdded " << vdom << "\n";);
     }
     
-    inline void propagate_data(statement_t &s) {
+    inline void propagate_data(const statement_t &s) {
       CRAB_LOG("assertion-crawler-step",
 	       crab::outs() << "*** " << s << "\n" << "\tBEFORE: " << m_sol << "\n");
       
@@ -499,27 +500,27 @@ public:
 	std::unique_ptr<add_data_deps> op = nullptr;
 
 	if (s.is_ref_make()) {
-	  auto make_ref = static_cast<make_ref_t*>(&s);
+	  auto make_ref = static_cast<const make_ref_t *>(&s);
 	  var_dom_t defs = var_dom_t::bottom();
 	  var_dom_t uses = var_dom_t::bottom();
 	  defs += make_ref->lhs();
 	  uses += make_ref->region();
 	  op = std::make_unique<add_data_deps>(uses, defs);
 	} else if (s.is_ref_remove()) {
-	  auto remove_ref = static_cast<remove_ref_t*>(&s);
+	  auto remove_ref = static_cast<const remove_ref_t *>(&s);
 	  var_dom_t defs = var_dom_t::bottom();
 	  var_dom_t uses = var_dom_t::bottom();
 	  uses += remove_ref->region();
 	  op = std::make_unique<add_data_deps>(uses, defs);
 	} else if (s.is_ref_load()) { 
-	  auto load_ref = static_cast<load_from_ref_t*>(&s);
+	  auto load_ref = static_cast<const load_from_ref_t *>(&s);
 	  var_dom_t defs = var_dom_t::bottom();
 	  var_dom_t uses = var_dom_t::bottom();
 	  defs += load_ref->lhs();
 	  uses += load_ref->region();
 	  op = std::make_unique<add_data_deps>(uses, defs);
 	} else if (s.is_ref_store()) {
-	  auto store_ref = static_cast<store_to_ref_t*>(&s);
+	  auto store_ref = static_cast<const store_to_ref_t *>(&s);
 	  var_dom_t defs = var_dom_t::bottom();
 	  var_dom_t uses = var_dom_t::bottom();
 	  defs += store_ref->region();
@@ -529,7 +530,7 @@ public:
 	  }
 	  op = std::make_unique<add_data_deps>(uses, defs);
 	} else if (s.is_ref_gep()) {
-	  auto gep_ref = static_cast<gep_ref_t*>(&s);
+	  auto gep_ref = static_cast<const gep_ref_t *>(&s);
 	  if (gep_ref->lhs() != gep_ref->rhs()) {
 	    var_dom_t defs = var_dom_t::bottom();
 	    var_dom_t uses = var_dom_t::bottom();
@@ -557,7 +558,7 @@ public:
       CRAB_LOG("assertion-crawler-step", crab::outs() << "\tAFTER " << m_sol << "\n";);
     }
 
-    inline void propagate_data_and_control(statement_t &s) {
+    inline void propagate_data_and_control(const statement_t &s) {
       CRAB_LOG("assertion-crawler-step", crab::outs()
 	       << "*** " << s << "\n"
 	       << "\tBEFORE: " << m_sol << "\n");
@@ -604,35 +605,35 @@ public:
       return m_sol;
     }
 
-    virtual void visit(bin_op_t &s) override {
+    virtual void visit(const bin_op_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(assign_t &s) override {
+    virtual void visit(const assign_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(assume_t &s) override {
+    virtual void visit(const assume_t &s) override {
       propagate_data_and_control(s);
     }
 
-    virtual void visit(select_t &s) override {
+    virtual void visit(const select_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(assert_t &s) override {
+    virtual void visit(const assert_t &s) override {
       process_assertion(s);
     }
 
-    virtual void visit(int_cast_t &s) override {
+    virtual void visit(const int_cast_t &s) override {
       propagate_data(s);
     }
     
-    virtual void visit(unreach_t &) override {
+    virtual void visit(const unreach_t &) override {
       m_sol.set_to_bottom();
     }
 
-    virtual void visit(havoc_t &s) override {
+    virtual void visit(const havoc_t &s) override {
       CRAB_LOG("assertion-crawler-step", crab::outs()
                                              << "*** " << s << "\n"
                                              << "\tBEFORE: " << m_sol << "\n");
@@ -710,7 +711,7 @@ public:
     }
 				      
     
-    virtual void visit(callsite_t &s) override {
+    virtual void visit(const callsite_t &s) override {
 
       CRAB_LOG("assertion-crawler-step-cs", crab::outs()
 	       << "*** " << s << "\n"
@@ -771,75 +772,75 @@ public:
 	       << "\tAFTER " << m_sol << "\n";);
     }
 
-    virtual void visit(intrinsic_t &s) override {
+    virtual void visit(const intrinsic_t &s) override {
       propagate_data(s);      
     }
 
-    virtual void visit(make_ref_t &s) override {
+    virtual void visit(const make_ref_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(remove_ref_t &s) override {
+    virtual void visit(const remove_ref_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(region_init_t &s) override {
+    virtual void visit(const region_init_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(region_copy_t &s) override {
+    virtual void visit(const region_copy_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(region_cast_t &s) override {
+    virtual void visit(const region_cast_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(load_from_ref_t &s) override {
+    virtual void visit(const load_from_ref_t &s) override {
       propagate_data(s);             
     }
 
-    virtual void visit(store_to_ref_t &s) override {
+    virtual void visit(const store_to_ref_t &s) override {
       propagate_data(s);       
     }
 
-    virtual void visit(gep_ref_t &s) override {
+    virtual void visit(const gep_ref_t &s) override {
       propagate_data(s); 
     }
 
-    virtual void visit(assume_ref_t &s) override {
+    virtual void visit(const assume_ref_t &s) override {
       propagate_data_and_control(s);
     }
 
-    virtual void visit(assert_ref_t &s) override {
+    virtual void visit(const assert_ref_t &s) override {
       process_assertion(s);
     }
     
-    virtual void visit(select_ref_t &s) override {
+    virtual void visit(const select_ref_t &s) override {
       propagate_data(s);
     }    
 
-    virtual void visit(bool_bin_op_t &s) override {
+    virtual void visit(const bool_bin_op_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(bool_assign_var_t &s) override {
+    virtual void visit(const bool_assign_var_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(bool_assign_cst_t &s) override {
+    virtual void visit(const bool_assign_cst_t &s) override {
       propagate_data(s);
     }
 
-    virtual void visit(bool_select_t &s) override {
+    virtual void visit(const bool_select_t &s) override {
       propagate_data(s);
     }
     
-    virtual void visit(bool_assume_t &s) override {
+    virtual void visit(const bool_assume_t &s) override {
       propagate_data_and_control(s);
     }
     
-    virtual void visit(bool_assert_t &s) override {
+    virtual void visit(const bool_assert_t &s) override {
       process_assertion(s);
     }
   };
@@ -896,10 +897,10 @@ public:
 
   virtual assertion_crawler_domain_t analyze(const basic_block_label_t &bb_id,
 					     assertion_crawler_domain_t out) override {
-    auto &bb = this->m_cfg.get_node(bb_id);
+    auto const &bb = this->m_cfg.get_node(bb_id);
     transfer_function vis(out, m_cdg, m_assert_map, m_summaries,
 			  m_opt_ignore_region_offset);
-    for (auto &s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
+    for (auto const&s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
       s.accept(&vis);
     }
     return vis.get_solution();
@@ -1001,18 +1002,19 @@ public:
   // return the dataflow facts of the pre-state at each program point in bb
   void get_results(
       const basic_block_label_t &b,
-      std::map<typename CFG::statement_t *, assert_map_domain_t> &res) const {
+      std::map<const typename CFG::statement_t *, assert_map_domain_t> &res)
+      const {
     auto it = m_results.find(b);
     if (it != m_results.end()) {
       if (!it->second.get_first().is_bottom()) {
-        auto &bb = this->m_cfg.get_node(b);
+        auto const &bb = this->m_cfg.get_node(b);
         typename assertion_crawler_op_t::transfer_function vis
 	  (it->second /* OUT dataflow facts */,
 	   m_assert_crawler_op.m_cdg,
 	   m_assert_crawler_op.m_assert_map,
 	   m_assert_crawler_op.m_summaries,
 	   m_assert_crawler_op.m_opt_ignore_region_offset);
-        for (auto &s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
+        for (auto const &s : boost::make_iterator_range(bb.rbegin(), bb.rend())) {
           s.accept(&vis);
           auto in = vis.get_solution().get_first();
           res.insert(std::make_pair(&s, in));

--- a/include/crab/analysis/dataflow/assumptions.hpp
+++ b/include/crab/analysis/dataflow/assumptions.hpp
@@ -152,7 +152,7 @@ protected:
   /** generate id's for assumptions **/
   unsigned m_id;
 
-  static bool can_overflow(statement_t &s) {
+  static bool can_overflow(const statement_t &s) {
     // TODO: cover select/assume with conditions that can overflow
 
     if (s.is_int_cast()) {
@@ -309,7 +309,7 @@ class assumption_naive_analysis : public assumption_analysis<CFG> {
       return; // already in visited
 
     bb_t &bb = this->m_cfg.get_node(r);
-    for (auto &s : boost::make_iterator_range(bb.begin(), bb.end())) {
+    for (auto const &s : boost::make_iterator_range(bb.begin(), bb.end())) {
       if (&s == a) {
         break;
       }
@@ -357,7 +357,7 @@ class assumption_dataflow_analysis : public assumption_analysis<CFG> {
   using assertion_crawler_t = crab::analyzer::assertion_crawler<CFG>;
   using assert_map_domain_t = typename assertion_crawler_t::assert_map_domain_t;
   using typename assumption_analysis_t::vector_assumption_ptr;
-  using pp_inv_map_t = std::map<statement_t *, assert_map_domain_t>;
+  using pp_inv_map_t = std::map<const statement_t *, assert_map_domain_t>;
   using basic_block_t = typename CFG::basic_block_t;
 
 public:
@@ -376,7 +376,7 @@ public:
 
       // find out if the block is of interest
       bool op_can_overflow = false;
-      for (auto &s : bb) {
+      for (auto const &s : bb) {
         if (assumption_analysis_t::can_overflow(s)) {
           op_can_overflow = true;
           break;
@@ -402,7 +402,7 @@ public:
       pp_inv_map_t pp_in_map;
       assert_crawler.get_results(bb.label(), pp_in_map);
 
-      for (auto &s : boost::make_iterator_range(bb.begin(), bb.end())) {
+      for (auto const &s : boost::make_iterator_range(bb.begin(), bb.end())) {
         if (!assumption_analysis_t::can_overflow(s))
           continue;
 

--- a/include/crab/analysis/fwd_abs_transformers.hpp
+++ b/include/crab/analysis/fwd_abs_transformers.hpp
@@ -110,7 +110,7 @@ public:
     return m_inv;
   }
 
-  virtual void exec(bin_op_t &stmt) override {
+  virtual void exec(const bin_op_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag &&
         (!(stmt.op() >= crab::cfg::BINOP_SDIV &&
@@ -140,7 +140,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);
   }
 
-  virtual void exec(select_t &stmt) override {
+  virtual void exec(const select_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -157,7 +157,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(assign_t &stmt) override {
+  virtual void exec(const assign_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -174,12 +174,12 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(assume_t &stmt) override {
+  virtual void exec(const assume_t &stmt) override {
     m_inv.operator+=(stmt.constraint());
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(assert_t &stmt) override {
+  virtual void exec(const assert_t &stmt) override {
     if (m_ignore_assert) {
       return;
     }
@@ -203,7 +203,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(int_cast_t &stmt) override {
+  virtual void exec(const int_cast_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -223,7 +223,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_assign_cst_t &stmt) override {
+  virtual void exec(const bool_assign_cst_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -244,7 +244,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_assign_var_t &stmt) override {
+  virtual void exec(const bool_assign_var_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -260,7 +260,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_bin_op_t &stmt) override {
+  virtual void exec(const bool_bin_op_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -281,12 +281,12 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_assume_t &stmt) override {
+  virtual void exec(const bool_assume_t &stmt) override {
     m_inv.assume_bool(stmt.cond(), stmt.is_negated());
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_select_t &stmt) override {
+  virtual void exec(const bool_select_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -303,7 +303,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(bool_assert_t &stmt) override {
+  virtual void exec(const bool_assert_t &stmt) override {
     if (m_ignore_assert) {
       return;
     }
@@ -312,7 +312,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(havoc_t &stmt) override {
+  virtual void exec(const havoc_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -329,12 +329,12 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(unreach_t &stmt) override {
+  virtual void exec(const unreach_t &stmt) override {
     m_inv.set_to_bottom();
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(arr_init_t &stmt) override {
+  virtual void exec(const arr_init_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -352,7 +352,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
   
-  virtual void exec(arr_store_t &stmt) override {
+  virtual void exec(const arr_store_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -375,7 +375,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(arr_load_t &stmt) override {
+  virtual void exec(const arr_load_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -392,7 +392,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(arr_assign_t &stmt) override {
+  virtual void exec(const arr_assign_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -409,7 +409,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(make_ref_t &stmt) override {
+  virtual void exec(const make_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -426,7 +426,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(remove_ref_t &stmt) override {
+  virtual void exec(const remove_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -443,7 +443,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
   
-  virtual void exec(region_init_t &stmt) override {
+  virtual void exec(const region_init_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -460,7 +460,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(region_copy_t &stmt) override {
+  virtual void exec(const region_copy_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -477,7 +477,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(region_cast_t &stmt) override {
+  virtual void exec(const region_cast_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -494,7 +494,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
   
-  virtual void exec(load_from_ref_t &stmt) override {
+  virtual void exec(const load_from_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -511,7 +511,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(store_to_ref_t &stmt) override {
+  virtual void exec(const store_to_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -528,7 +528,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(gep_ref_t &stmt) override {
+  virtual void exec(const gep_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -546,12 +546,12 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(assume_ref_t &stmt) override {
+  virtual void exec(const assume_ref_t &stmt) override {
     m_inv.ref_assume(stmt.constraint());
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(assert_ref_t &stmt) override {
+  virtual void exec(const assert_ref_t &stmt) override {
     if (m_ignore_assert) {
       return;
     }
@@ -559,7 +559,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(select_ref_t &stmt) override {
+  virtual void exec(const select_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -579,7 +579,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(int_to_ref_t &stmt) override {
+  virtual void exec(const int_to_ref_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -596,7 +596,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(ref_to_int_t &stmt) override {
+  virtual void exec(const ref_to_int_t &stmt) override {
     bool pre_bot = false;
     if (::crab::CrabSanityCheckFlag) {
       pre_bot = m_inv.is_bottom();
@@ -613,7 +613,7 @@ public:
     CRAB_VERBOSE_IF(5, crab::outs() << "EXECUTED " << stmt << " :" << m_inv <<"\n";);    
   }
 
-  virtual void exec(intrinsic_t &cs) override {
+  virtual void exec(const intrinsic_t &cs) override {
     if (cs.get_intrinsic_name() == "print_invariants") {
       // Note that we don't call the abstract transformer "intrinsic".
       // Instead, we directly print the projected invariants here.
@@ -633,7 +633,7 @@ public:
     }
   }
 
-  virtual void exec(callsite_t &cs) override {
+  virtual void exec(const callsite_t &cs) override {
     for (const variable_t &vt : cs.get_lhs()) {
       m_inv.operator-=(vt); // havoc
     }

--- a/include/crab/analysis/fwd_analyzer.hpp
+++ b/include/crab/analysis/fwd_analyzer.hpp
@@ -76,9 +76,9 @@ private:
   //! Given a basic block and the invariant at the entry it produces
   //! the invariant at the exit of the block.
   abs_dom_t analyze(const basic_block_label_t &node, abs_dom_t &&inv) override {
-    auto &b = get_cfg().get_node(node);
+    auto const &b = get_cfg().get_node(node);
     m_abs_tr->set_abs_value(std::move(inv));
-    for (auto &s : b) {
+    for (auto const &s : b) {
       s.accept(&*m_abs_tr);
     }
     // We cannot avoid the copy of res because we cannot move

--- a/include/crab/analysis/inter/bottom_up_inter_analyzer.hpp
+++ b/include/crab/analysis/inter/bottom_up_inter_analyzer.hpp
@@ -400,7 +400,7 @@ public:
 
   ~bu_summ_abs_transformer() = default;
 
-  virtual void exec(callsite_t &cs) override {
+  virtual void exec(const callsite_t &cs) override {
     if (m_sum_tbl.has_summary(cs)) {
       auto const& summ = m_sum_tbl.get(cs);
       reuse_summary(this->m_inv, cs, summ);
@@ -533,7 +533,7 @@ public:
 
   ~td_summ_abs_transformer() = default;
 
-  virtual void exec(callsite_t &cs) override {
+  virtual void exec(const callsite_t &cs) override {
     /**
      * This code is similar to inter_abstract_operations::callee_entry but
      * switching the abstract domain.

--- a/include/crab/analysis/inter/top_down_inter_analyzer.hpp
+++ b/include/crab/analysis/inter/top_down_inter_analyzer.hpp
@@ -1372,7 +1372,7 @@ public:
 
   global_context_t &get_context() { return m_ctx; }
 
-  virtual void exec(callsite_t &cs) override {
+  virtual void exec(const callsite_t &cs) override {
     if (!m_cg.has_callee(cs)) {
       CRAB_ERROR("Cannot find callee CFG for ", cs);
     }

--- a/include/crab/cfg/cfg.hpp
+++ b/include/crab/cfg/cfg.hpp
@@ -274,6 +274,9 @@ template <class BasicBlockLabel, class Number, class VariableName>
 struct statement_visitor;
 
 template <class BasicBlockLabel, class Number, class VariableName>
+struct const_statement_visitor;
+
+template <class BasicBlockLabel, class Number, class VariableName>
 class statement {
 public:
   using live_t = live<Number, VariableName>;
@@ -337,6 +340,10 @@ public:
   virtual void
   accept(statement_visitor<BasicBlockLabel, Number, VariableName> *) = 0;
 
+  virtual void
+  accept(const_statement_visitor<BasicBlockLabel, Number, VariableName> *)
+      const = 0;
+
   virtual void write(crab_os &o) const = 0;
 
   virtual statement<BasicBlockLabel, Number, VariableName> *
@@ -368,6 +375,12 @@ public:
   virtual void
   accept(statement_visitor<BasicBlockLabel, Number, VariableName> *v) override {
     v->visit(static_cast<Derived &>(*this));
+  }
+
+  virtual void
+  accept(const_statement_visitor<BasicBlockLabel, Number, VariableName> *v)
+      const override {
+    v->visit(static_cast<const Derived &>(*this));
   }
 };
 
@@ -2418,6 +2431,11 @@ public:
     v->visit(*this);
   }
 
+  void accept(const_statement_visitor<BasicBlockLabel, Number, VariableName> *v)
+      const {
+    v->visit(*this);
+  }
+
   std::pair<succ_iterator, succ_iterator> next_blocks() {
     return std::make_pair(m_next.begin(), m_next.end());
   }
@@ -2911,6 +2929,12 @@ public:
     v->visit(*this);
   }
 
+  void accept(
+      const_statement_visitor<basic_block_label_t, number_t, varname_t> *v)
+      const {
+    v->visit(*this);
+  }
+
   live_domain_t &live() { return _bb.live(); }
 
   const live_domain_t &live() const { return _bb.live(); }
@@ -2952,7 +2976,14 @@ public:
   }
 };
 
-/** Visitor class for statements **/
+/**
+ * Visitor class for statements that may modify the visited statement.
+ *
+ * Prefer const_statement_visitor (below) for read-only visitors: it can
+ * also be applied to a const basic block or a const CFG.
+ *
+ * NOTE: any new statement kind must be added to both visitors.
+ **/
 template <class BasicBlockLabel, class Number, class VariableName>
 struct statement_visitor {
   using bin_op_t = binary_op<BasicBlockLabel, Number, VariableName>;
@@ -2974,10 +3005,8 @@ struct statement_visitor {
   using region_init_t = region_init_stmt<BasicBlockLabel, Number, VariableName>;
   using region_copy_t = region_copy_stmt<BasicBlockLabel, Number, VariableName>;
   using region_cast_t = region_cast_stmt<BasicBlockLabel, Number, VariableName>;  
-  using load_from_ref_t =
-      load_from_ref_stmt<BasicBlockLabel, Number, VariableName>;
-  using store_to_ref_t =
-      store_to_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using load_from_ref_t = load_from_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using store_to_ref_t = store_to_ref_stmt<BasicBlockLabel, Number, VariableName>;
   using gep_ref_t = gep_ref_stmt<BasicBlockLabel, Number, VariableName>;
   using assume_ref_t = assume_ref_stmt<BasicBlockLabel, Number, VariableName>;
   using assert_ref_t = assert_ref_stmt<BasicBlockLabel, Number, VariableName>;
@@ -2985,10 +3014,8 @@ struct statement_visitor {
   using int_to_ref_t = int_to_ref_stmt<BasicBlockLabel, Number, VariableName>;
   using ref_to_int_t = ref_to_int_stmt<BasicBlockLabel, Number, VariableName>;
   using bool_bin_op_t = bool_binary_op<BasicBlockLabel, Number, VariableName>;
-  using bool_assign_cst_t =
-      bool_assign_cst<BasicBlockLabel, Number, VariableName>;
-  using bool_assign_var_t =
-      bool_assign_var<BasicBlockLabel, Number, VariableName>;
+  using bool_assign_cst_t = bool_assign_cst<BasicBlockLabel, Number, VariableName>;
+  using bool_assign_var_t = bool_assign_var<BasicBlockLabel, Number, VariableName>;
   using bool_assume_t = bool_assume_stmt<BasicBlockLabel, Number, VariableName>;
   using bool_select_t = bool_select_stmt<BasicBlockLabel, Number, VariableName>;
   using bool_assert_t = bool_assert_stmt<BasicBlockLabel, Number, VariableName>;
@@ -3040,6 +3067,100 @@ struct statement_visitor {
   }
 
   virtual ~statement_visitor() {}
+};
+
+/**
+ * Visitor class for statements that does not modify the visited statement.
+ *
+ * Unlike statement_visitor, this one can be applied to a const basic
+ * block or a const CFG.
+ *
+ * NOTE: any new statement kind must be added to both visitors.
+ **/
+template <class BasicBlockLabel, class Number, class VariableName>
+struct const_statement_visitor {
+  using bin_op_t = binary_op<BasicBlockLabel, Number, VariableName>;
+  using assign_t = assignment<BasicBlockLabel, Number, VariableName>;
+  using assume_t = assume_stmt<BasicBlockLabel, Number, VariableName>;
+  using select_t = select_stmt<BasicBlockLabel, Number, VariableName>;
+  using assert_t = assert_stmt<BasicBlockLabel, Number, VariableName>;
+  using int_cast_t = int_cast_stmt<BasicBlockLabel, Number, VariableName>;
+  using havoc_t = havoc_stmt<BasicBlockLabel, Number, VariableName>;
+  using unreach_t = unreachable_stmt<BasicBlockLabel, Number, VariableName>;
+  using callsite_t = callsite_stmt<BasicBlockLabel, Number, VariableName>;
+  using intrinsic_t = intrinsic_stmt<BasicBlockLabel, Number, VariableName>;
+  using arr_init_t = array_init_stmt<BasicBlockLabel, Number, VariableName>;
+  using arr_store_t = array_store_stmt<BasicBlockLabel, Number, VariableName>;
+  using arr_load_t = array_load_stmt<BasicBlockLabel, Number, VariableName>;
+  using arr_assign_t = array_assign_stmt<BasicBlockLabel, Number, VariableName>;
+  using make_ref_t = make_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using remove_ref_t = remove_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using region_init_t = region_init_stmt<BasicBlockLabel, Number, VariableName>;
+  using region_copy_t = region_copy_stmt<BasicBlockLabel, Number, VariableName>;
+  using region_cast_t = region_cast_stmt<BasicBlockLabel, Number, VariableName>;  
+  using load_from_ref_t = load_from_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using store_to_ref_t = store_to_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using gep_ref_t = gep_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using assume_ref_t = assume_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using assert_ref_t = assert_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using select_ref_t = ref_select_stmt<BasicBlockLabel, Number, VariableName>;
+  using int_to_ref_t = int_to_ref_stmt<BasicBlockLabel, Number, VariableName>;
+  using ref_to_int_t = ref_to_int_stmt<BasicBlockLabel, Number, VariableName>;
+  using bool_bin_op_t = bool_binary_op<BasicBlockLabel, Number, VariableName>;
+  using bool_assign_cst_t = bool_assign_cst<BasicBlockLabel, Number, VariableName>;
+  using bool_assign_var_t = bool_assign_var<BasicBlockLabel, Number, VariableName>;
+  using bool_assume_t = bool_assume_stmt<BasicBlockLabel, Number, VariableName>;
+  using bool_select_t = bool_select_stmt<BasicBlockLabel, Number, VariableName>;
+  using bool_assert_t = bool_assert_stmt<BasicBlockLabel, Number, VariableName>;
+
+  virtual void visit(const bin_op_t &){};
+  virtual void visit(const assign_t &){};
+  virtual void visit(const assume_t &){};
+  virtual void visit(const select_t &){};
+  virtual void visit(const assert_t &){};
+  virtual void visit(const int_cast_t &){};
+  virtual void visit(const unreach_t &){};
+  virtual void visit(const havoc_t &){};
+  virtual void visit(const callsite_t &){};
+  virtual void visit(const intrinsic_t &){};
+  virtual void visit(const arr_init_t &){};
+  virtual void visit(const arr_store_t &){};
+  virtual void visit(const arr_load_t &){};
+  virtual void visit(const arr_assign_t &){};
+  virtual void visit(const region_init_t &) {}
+  virtual void visit(const region_copy_t &) {}
+  virtual void visit(const region_cast_t &) {}  
+  virtual void visit(const make_ref_t &) {}
+  virtual void visit(const remove_ref_t &) {}  
+  virtual void visit(const load_from_ref_t &) {}
+  virtual void visit(const store_to_ref_t &) {}
+  virtual void visit(const gep_ref_t &) {}
+  virtual void visit(const assume_ref_t &){};
+  virtual void visit(const assert_ref_t &){};
+  virtual void visit(const select_ref_t &){};
+  virtual void visit(const int_to_ref_t &){};
+  virtual void visit(const ref_to_int_t &){};
+  virtual void visit(const bool_bin_op_t &){};
+  virtual void visit(const bool_assign_cst_t &){};
+  virtual void visit(const bool_assign_var_t &){};
+  virtual void visit(const bool_assume_t &){};
+  virtual void visit(const bool_select_t &){};
+  virtual void visit(const bool_assert_t &){};
+
+  void visit(const basic_block<BasicBlockLabel, VariableName, Number> &b) {
+    for (auto const &s : b) {
+      s.accept(this);
+    }
+  }
+
+  template <typename BasicBlock>
+  void visit(const basic_block_rev<BasicBlock> &b) {
+    for (auto const &s : b) {
+      s.accept(this);
+    }
+  }
+
+  virtual ~const_statement_visitor() {}
 };
 
 template <class Number, class VariableName>

--- a/include/crab/cfg/cfg_to_json.hpp
+++ b/include/crab/cfg/cfg_to_json.hpp
@@ -73,49 +73,49 @@ namespace json_impl {
 
 template <typename CFG>
 class statement_to_json_visitor
-    : public statement_visitor<typename CFG::basic_block_label_t,
-                               typename CFG::number_t,
-                               typename CFG::varname_t> {
+    : public const_statement_visitor<typename CFG::basic_block_label_t,
+                                     typename CFG::number_t,
+                                     typename CFG::varname_t> {
 
   using basic_block_label_t = typename CFG::basic_block_label_t;
   using number_t = typename CFG::number_t;
   using varname_t = typename CFG::varname_t;
-  using statement_visitor_t =
-      statement_visitor<basic_block_label_t, number_t, varname_t>;
+  using const_statement_visitor_t =
+      const_statement_visitor<basic_block_label_t, number_t, varname_t>;
 
-  using bin_op_t = typename statement_visitor_t::bin_op_t;
-  using assign_t = typename statement_visitor_t::assign_t;
-  using assume_t = typename statement_visitor_t::assume_t;
-  using select_t = typename statement_visitor_t::select_t;
-  using assert_t = typename statement_visitor_t::assert_t;
-  using int_cast_t = typename statement_visitor_t::int_cast_t;
-  using unreach_t = typename statement_visitor_t::unreach_t;
-  using havoc_t = typename statement_visitor_t::havoc_t;
-  using callsite_t = typename statement_visitor_t::callsite_t;
-  using intrinsic_t = typename statement_visitor_t::intrinsic_t;
-  using arr_init_t = typename statement_visitor_t::arr_init_t;
-  using arr_store_t = typename statement_visitor_t::arr_store_t;
-  using arr_load_t = typename statement_visitor_t::arr_load_t;
-  using arr_assign_t = typename statement_visitor_t::arr_assign_t;
-  using bool_bin_op_t = typename statement_visitor_t::bool_bin_op_t;
-  using bool_assign_cst_t = typename statement_visitor_t::bool_assign_cst_t;
-  using bool_assign_var_t = typename statement_visitor_t::bool_assign_var_t;
-  using bool_assume_t = typename statement_visitor_t::bool_assume_t;
-  using bool_select_t = typename statement_visitor_t::bool_select_t;
-  using bool_assert_t = typename statement_visitor_t::bool_assert_t;
-  using region_init_t = typename statement_visitor_t::region_init_t;
-  using region_copy_t = typename statement_visitor_t::region_copy_t;
-  using region_cast_t = typename statement_visitor_t::region_cast_t;
-  using make_ref_t = typename statement_visitor_t::make_ref_t;
-  using remove_ref_t = typename statement_visitor_t::remove_ref_t;
-  using load_from_ref_t = typename statement_visitor_t::load_from_ref_t;
-  using store_to_ref_t = typename statement_visitor_t::store_to_ref_t;
-  using gep_ref_t = typename statement_visitor_t::gep_ref_t;
-  using assume_ref_t = typename statement_visitor_t::assume_ref_t;
-  using assert_ref_t = typename statement_visitor_t::assert_ref_t;
-  using select_ref_t = typename statement_visitor_t::select_ref_t;
-  using int_to_ref_t = typename statement_visitor_t::int_to_ref_t;
-  using ref_to_int_t = typename statement_visitor_t::ref_to_int_t;
+  using bin_op_t = typename const_statement_visitor_t::bin_op_t;
+  using assign_t = typename const_statement_visitor_t::assign_t;
+  using assume_t = typename const_statement_visitor_t::assume_t;
+  using select_t = typename const_statement_visitor_t::select_t;
+  using assert_t = typename const_statement_visitor_t::assert_t;
+  using int_cast_t = typename const_statement_visitor_t::int_cast_t;
+  using unreach_t = typename const_statement_visitor_t::unreach_t;
+  using havoc_t = typename const_statement_visitor_t::havoc_t;
+  using callsite_t = typename const_statement_visitor_t::callsite_t;
+  using intrinsic_t = typename const_statement_visitor_t::intrinsic_t;
+  using arr_init_t = typename const_statement_visitor_t::arr_init_t;
+  using arr_store_t = typename const_statement_visitor_t::arr_store_t;
+  using arr_load_t = typename const_statement_visitor_t::arr_load_t;
+  using arr_assign_t = typename const_statement_visitor_t::arr_assign_t;
+  using bool_bin_op_t = typename const_statement_visitor_t::bool_bin_op_t;
+  using bool_assign_cst_t = typename const_statement_visitor_t::bool_assign_cst_t;
+  using bool_assign_var_t = typename const_statement_visitor_t::bool_assign_var_t;
+  using bool_assume_t = typename const_statement_visitor_t::bool_assume_t;
+  using bool_select_t = typename const_statement_visitor_t::bool_select_t;
+  using bool_assert_t = typename const_statement_visitor_t::bool_assert_t;
+  using region_init_t = typename const_statement_visitor_t::region_init_t;
+  using region_copy_t = typename const_statement_visitor_t::region_copy_t;
+  using region_cast_t = typename const_statement_visitor_t::region_cast_t;
+  using make_ref_t = typename const_statement_visitor_t::make_ref_t;
+  using remove_ref_t = typename const_statement_visitor_t::remove_ref_t;
+  using load_from_ref_t = typename const_statement_visitor_t::load_from_ref_t;
+  using store_to_ref_t = typename const_statement_visitor_t::store_to_ref_t;
+  using gep_ref_t = typename const_statement_visitor_t::gep_ref_t;
+  using assume_ref_t = typename const_statement_visitor_t::assume_ref_t;
+  using assert_ref_t = typename const_statement_visitor_t::assert_ref_t;
+  using select_ref_t = typename const_statement_visitor_t::select_ref_t;
+  using int_to_ref_t = typename const_statement_visitor_t::int_to_ref_t;
+  using ref_to_int_t = typename const_statement_visitor_t::ref_to_int_t;
 
   crab::json::writer &m_w;
 
@@ -194,7 +194,7 @@ public:
 
   // -- integer statements ----------------------------------------------------
 
-  virtual void visit(bin_op_t &s) override {
+  virtual void visit(const bin_op_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "binop");
     m_w.kv_string("op", op_name(s.op()));
@@ -204,7 +204,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(assign_t &s) override {
+  virtual void visit(const assign_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "assign");
     expr("rhs", s.rhs());
@@ -212,14 +212,14 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(assume_t &s) override {
+  virtual void visit(const assume_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "assume");
     cst("cond", s.constraint());
     m_w.end_object();
   }
 
-  virtual void visit(assert_t &s) override {
+  virtual void visit(const assert_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "assert");
     cst("cond", s.constraint());
@@ -227,7 +227,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(select_t &s) override {
+  virtual void visit(const select_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "select");
     cst("cond", s.cond());
@@ -237,7 +237,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(int_cast_t &s) override {
+  virtual void visit(const int_cast_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "cast");
     m_w.kv_string("op", op_name(s.op()));
@@ -248,14 +248,14 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(havoc_t &s) override {
+  virtual void visit(const havoc_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "havoc");
     var("lhs", s.get_variable());
     m_w.end_object();
   }
 
-  virtual void visit(unreach_t &) override {
+  virtual void visit(const unreach_t &) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "unreachable");
     m_w.end_object();
@@ -263,7 +263,7 @@ public:
 
   // -- boolean statements ----------------------------------------------------
 
-  virtual void visit(bool_assign_cst_t &s) override {
+  virtual void visit(const bool_assign_cst_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_assign_cst");
     // The right-hand side is either a linear or a reference constraint. They
@@ -280,7 +280,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(bool_assign_var_t &s) override {
+  virtual void visit(const bool_assign_var_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_assign_var");
     var("rhs", s.rhs());
@@ -289,7 +289,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(bool_bin_op_t &s) override {
+  virtual void visit(const bool_bin_op_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_binop");
     m_w.kv_string("op", op_name(s.op()));
@@ -299,7 +299,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(bool_assume_t &s) override {
+  virtual void visit(const bool_assume_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_assume");
     var("cond", s.cond());
@@ -307,7 +307,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(bool_assert_t &s) override {
+  virtual void visit(const bool_assert_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_assert");
     var("cond", s.cond());
@@ -315,7 +315,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(bool_select_t &s) override {
+  virtual void visit(const bool_select_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "bool_select");
     var("cond", s.cond());
@@ -327,7 +327,7 @@ public:
 
   // -- arrays ----------------------------------------------------------------
 
-  virtual void visit(arr_init_t &s) override {
+  virtual void visit(const arr_init_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "array_init");
     expr("lb", s.lb_index());
@@ -338,7 +338,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(arr_store_t &s) override {
+  virtual void visit(const arr_store_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "array_store");
     expr("lb", s.lb_index());
@@ -349,7 +349,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(arr_load_t &s) override {
+  virtual void visit(const arr_load_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "array_load");
     var("array", s.array());
@@ -359,7 +359,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(arr_assign_t &s) override {
+  virtual void visit(const arr_assign_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "array_assign");
     var("rhs", s.rhs());
@@ -369,7 +369,7 @@ public:
 
   // -- calls -----------------------------------------------------------------
 
-  virtual void visit(callsite_t &s) override {
+  virtual void visit(const callsite_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "callsite");
     m_w.kv_string("callee", s.get_func_name());
@@ -378,7 +378,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(intrinsic_t &s) override {
+  virtual void visit(const intrinsic_t &s) override {
     const std::string &name = s.get_intrinsic_name();
     // Directives for the value partitioning domain. They constrain how the
     // analysis explores the program, not what the program does, so they have no
@@ -392,14 +392,14 @@ public:
 
   // -- regions and references ------------------------------------------------
 
-  virtual void visit(region_init_t &s) override {
+  virtual void visit(const region_init_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "region_init");
     var("lhs", s.region());
     m_w.end_object();
   }
 
-  virtual void visit(region_copy_t &s) override {
+  virtual void visit(const region_copy_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "region_copy");
     var("rhs", s.rhs_region());
@@ -407,7 +407,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(region_cast_t &s) override {
+  virtual void visit(const region_cast_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "region_cast");
     var("rhs", s.src());
@@ -417,7 +417,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(make_ref_t &s) override {
+  virtual void visit(const make_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "make_ref");
     var_or_cst("size", s.size());
@@ -430,7 +430,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(remove_ref_t &s) override {
+  virtual void visit(const remove_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "remove_ref");
     var("region", s.region());
@@ -438,7 +438,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(load_from_ref_t &s) override {
+  virtual void visit(const load_from_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "load_from_ref");
     var("region", s.region());
@@ -448,7 +448,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(store_to_ref_t &s) override {
+  virtual void visit(const store_to_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "store_to_ref");
     var("region", s.region());
@@ -458,7 +458,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(gep_ref_t &s) override {
+  virtual void visit(const gep_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "gep_ref");
     var("rhs_region", s.rhs_region());
@@ -470,14 +470,14 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(assume_ref_t &s) override {
+  virtual void visit(const assume_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "assume_ref");
     ref_cst("cond", s.constraint());
     m_w.end_object();
   }
 
-  virtual void visit(assert_ref_t &s) override {
+  virtual void visit(const assert_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "assert_ref");
     ref_cst("cond", s.constraint());
@@ -485,7 +485,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(select_ref_t &s) override {
+  virtual void visit(const select_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "select_ref");
     var("cond", s.cond());
@@ -501,7 +501,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(int_to_ref_t &s) override {
+  virtual void visit(const int_to_ref_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "int_to_ref");
     var("rhs", s.int_var());
@@ -511,7 +511,7 @@ public:
     m_w.end_object();
   }
 
-  virtual void visit(ref_to_int_t &s) override {
+  virtual void visit(const ref_to_int_t &s) override {
     m_w.begin_object();
     m_w.kv_string("stmt", "ref_to_int");
     var("rhs_region", s.region());
@@ -552,11 +552,8 @@ void basic_block_to_json(const CFG &cfg,
 
   w.key("stmts");
   w.begin_array();
-  // statement_visitor::visit takes non-const references, so the block is
-  // const_cast here; nothing below mutates it.
-  const basic_block_t &cbb = cfg.get_node(label);
-  basic_block_t &bb = const_cast<basic_block_t &>(cbb);
-  for (auto &s : bb) {
+  const basic_block_t &bb = cfg.get_node(label);
+  for (auto const&s : bb) {
     json_impl::statement_to_json_visitor<CFG> vis(w);
     s.accept(&vis);
   }

--- a/include/crab/cfg/type_checker.hpp
+++ b/include/crab/cfg/type_checker.hpp
@@ -38,7 +38,7 @@ public:
 
     // check all statement are well typed
     type_checker_visitor<CFG> vis;
-    for (auto &b : boost::make_iterator_range(m_cfg.begin(), m_cfg.end())) {
+    for (auto const&b : boost::make_iterator_range(m_cfg.begin(), m_cfg.end())) {
       b.accept(&vis);
     }
 
@@ -48,50 +48,50 @@ public:
 
 template <class CFG>
 class type_checker_visitor
-    : public statement_visitor<typename CFG::basic_block_label_t,
-                               typename CFG::number_t,
-                               typename CFG::varname_t> {
+    : public const_statement_visitor<typename CFG::basic_block_label_t,
+                                     typename CFG::number_t,
+                                     typename CFG::varname_t> {
 
   using B = typename CFG::basic_block_label_t;
   using V = typename CFG::varname_t;
   using N = typename CFG::number_t;
   using statement_t = typename CFG::statement_t;
 
-  using bin_op_t = typename statement_visitor<B, N, V>::bin_op_t;
-  using assign_t = typename statement_visitor<B, N, V>::assign_t;
-  using assume_t = typename statement_visitor<B, N, V>::assume_t;
-  using assert_t = typename statement_visitor<B, N, V>::assert_t;
-  using int_cast_t = typename statement_visitor<B, N, V>::int_cast_t;
-  using select_t = typename statement_visitor<B, N, V>::select_t;
-  using havoc_t = typename statement_visitor<B, N, V>::havoc_t;
-  using unreach_t = typename statement_visitor<B, N, V>::unreach_t;
-  using callsite_t = typename statement_visitor<B, N, V>::callsite_t;
-  using intrinsic_t = typename statement_visitor<B, N, V>::intrinsic_t;
-  using arr_init_t = typename statement_visitor<B, N, V>::arr_init_t;
-  using arr_store_t = typename statement_visitor<B, N, V>::arr_store_t;
-  using arr_load_t = typename statement_visitor<B, N, V>::arr_load_t;
-  using arr_assign_t = typename statement_visitor<B, N, V>::arr_assign_t;
-  using make_ref_t = typename statement_visitor<B, N, V>::make_ref_t;
-  using remove_ref_t = typename statement_visitor<B, N, V>::remove_ref_t;
-  using region_init_t = typename statement_visitor<B, N, V>::region_init_t;
-  using region_copy_t = typename statement_visitor<B, N, V>::region_copy_t;
-  using region_cast_t = typename statement_visitor<B, N, V>::region_cast_t;
-  using load_from_ref_t = typename statement_visitor<B, N, V>::load_from_ref_t;
-  using store_to_ref_t = typename statement_visitor<B, N, V>::store_to_ref_t;
-  using gep_ref_t = typename statement_visitor<B, N, V>::gep_ref_t;
-  using assume_ref_t = typename statement_visitor<B, N, V>::assume_ref_t;
-  using assert_ref_t = typename statement_visitor<B, N, V>::assert_ref_t;
-  using select_ref_t = typename statement_visitor<B, N, V>::select_ref_t;
-  using int_to_ref_t = typename statement_visitor<B, N, V>::int_to_ref_t;
-  using ref_to_int_t = typename statement_visitor<B, N, V>::ref_to_int_t;
-  using bool_bin_op_t = typename statement_visitor<B, N, V>::bool_bin_op_t;
+  using bin_op_t = typename const_statement_visitor<B, N, V>::bin_op_t;
+  using assign_t = typename const_statement_visitor<B, N, V>::assign_t;
+  using assume_t = typename const_statement_visitor<B, N, V>::assume_t;
+  using assert_t = typename const_statement_visitor<B, N, V>::assert_t;
+  using int_cast_t = typename const_statement_visitor<B, N, V>::int_cast_t;
+  using select_t = typename const_statement_visitor<B, N, V>::select_t;
+  using havoc_t = typename const_statement_visitor<B, N, V>::havoc_t;
+  using unreach_t = typename const_statement_visitor<B, N, V>::unreach_t;
+  using callsite_t = typename const_statement_visitor<B, N, V>::callsite_t;
+  using intrinsic_t = typename const_statement_visitor<B, N, V>::intrinsic_t;
+  using arr_init_t = typename const_statement_visitor<B, N, V>::arr_init_t;
+  using arr_store_t = typename const_statement_visitor<B, N, V>::arr_store_t;
+  using arr_load_t = typename const_statement_visitor<B, N, V>::arr_load_t;
+  using arr_assign_t = typename const_statement_visitor<B, N, V>::arr_assign_t;
+  using make_ref_t = typename const_statement_visitor<B, N, V>::make_ref_t;
+  using remove_ref_t = typename const_statement_visitor<B, N, V>::remove_ref_t;
+  using region_init_t = typename const_statement_visitor<B, N, V>::region_init_t;
+  using region_copy_t = typename const_statement_visitor<B, N, V>::region_copy_t;
+  using region_cast_t = typename const_statement_visitor<B, N, V>::region_cast_t;
+  using load_from_ref_t = typename const_statement_visitor<B, N, V>::load_from_ref_t;
+  using store_to_ref_t = typename const_statement_visitor<B, N, V>::store_to_ref_t;
+  using gep_ref_t = typename const_statement_visitor<B, N, V>::gep_ref_t;
+  using assume_ref_t = typename const_statement_visitor<B, N, V>::assume_ref_t;
+  using assert_ref_t = typename const_statement_visitor<B, N, V>::assert_ref_t;
+  using select_ref_t = typename const_statement_visitor<B, N, V>::select_ref_t;
+  using int_to_ref_t = typename const_statement_visitor<B, N, V>::int_to_ref_t;
+  using ref_to_int_t = typename const_statement_visitor<B, N, V>::ref_to_int_t;
+  using bool_bin_op_t = typename const_statement_visitor<B, N, V>::bool_bin_op_t;
   using bool_assign_cst_t =
-      typename statement_visitor<B, N, V>::bool_assign_cst_t;
+      typename const_statement_visitor<B, N, V>::bool_assign_cst_t;
   using bool_assign_var_t =
-      typename statement_visitor<B, N, V>::bool_assign_var_t;
-  using bool_assume_t = typename statement_visitor<B, N, V>::bool_assume_t;
-  using bool_assert_t = typename statement_visitor<B, N, V>::bool_assert_t;
-  using bool_select_t = typename statement_visitor<B, N, V>::bool_select_t;
+      typename const_statement_visitor<B, N, V>::bool_assign_var_t;
+  using bool_assume_t = typename const_statement_visitor<B, N, V>::bool_assume_t;
+  using bool_assert_t = typename const_statement_visitor<B, N, V>::bool_assert_t;
+  using bool_select_t = typename const_statement_visitor<B, N, V>::bool_select_t;
 
   using lin_exp_t = ikos::linear_expression<N, V>;
   using lin_cst_t = ikos::linear_constraint<N, V>;
@@ -133,7 +133,7 @@ class type_checker_visitor
   }
 
   // check variable is a number
-  void check_num(const variable_t &v, std::string msg, statement_t &s) {
+  void check_num(const variable_t &v, std::string msg, const statement_t &s) {
     if (!v.get_type().is_integer() && !v.get_type().is_real()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -142,7 +142,7 @@ class type_checker_visitor
   }
 
   // check variable is an integer or boolean
-  void check_int_or_bool(const variable_t &v, std::string msg, statement_t &s) {
+  void check_int_or_bool(const variable_t &v, std::string msg, const statement_t &s) {
     if (!v.get_type().is_integer() && !v.get_type().is_bool()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -151,7 +151,7 @@ class type_checker_visitor
   }
 
   // check variable is an integer
-  void check_int(const variable_t &v, std::string msg, statement_t &s) {
+  void check_int(const variable_t &v, std::string msg, const statement_t &s) {
     if (!v.get_type().is_integer()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -160,7 +160,7 @@ class type_checker_visitor
   }
 
   // check variable is a boolean
-  void check_bool(const variable_t &v, std::string msg, statement_t &s) {
+  void check_bool(const variable_t &v, std::string msg, const statement_t &s) {
     if (!v.get_type().is_bool()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -169,7 +169,7 @@ class type_checker_visitor
   }
 
   // check variable is region
-  void check_region(const variable_t &v, statement_t &s) {
+  void check_region(const variable_t &v, const statement_t &s) {
     if (!v.get_type().is_region()) {
       crab::crab_string_os os;
       os << "(type checking) " << v << " is not a region variable in " << s;
@@ -178,7 +178,7 @@ class type_checker_visitor
   }
 
   // check variable is a reference
-  void check_ref(const variable_t &v, std::string msg, statement_t &s) {
+  void check_ref(const variable_t &v, std::string msg, const statement_t &s) {
     if (!v.get_type().is_reference()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -187,7 +187,7 @@ class type_checker_visitor
   }
 
   void check_ref(const variable_or_constant_t &v, std::string msg,
-                 statement_t &s) {
+                 const statement_t &s) {
     if (!v.get_type().is_reference()) {
       crab::crab_string_os os;
       os << "(type checking) " << v << " is not a reference";
@@ -201,7 +201,7 @@ class type_checker_visitor
 
   void check_region_consistent_with_data(const variable_t &rgn,
                                          const variable_type &data_type,
-                                         statement_t &s) {
+                                         const statement_t &s) {
     if (!rgn.get_type().is_region()) {
       return;
     }
@@ -233,7 +233,7 @@ class type_checker_visitor
 
   // check two variables have same types
   void check_same_type(const variable_t &v1, const variable_t &v2,
-                       std::string msg, statement_t &s) {
+                       std::string msg, const statement_t &s) {
     if (v1.get_type() != v2.get_type()) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -243,7 +243,7 @@ class type_checker_visitor
 
   // check two variables have different names
   void check_different_name(const variable_t &v1, const variable_t &v2,
-                            std::string msg, statement_t &s) {
+                            std::string msg, const statement_t &s) {
     if (v1 == v2) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -252,7 +252,7 @@ class type_checker_visitor
   }
 
   // check linear expressinon is just a number or variable
-  void check_num_or_var(const lin_exp_t &e, std::string msg, statement_t &s) {
+  void check_num_or_var(const lin_exp_t &e, std::string msg, const statement_t &s) {
     if (!(e.is_constant() || e.get_variable())) {
       crab::crab_string_os os;
       os << "(type checking) " << msg << " in " << s;
@@ -261,7 +261,7 @@ class type_checker_visitor
   }
 
   // check variable is an array
-  void check_is_array(const variable_t &v, statement_t &s) {
+  void check_is_array(const variable_t &v, const statement_t &s) {
     if (!v.get_type().is_array()) {
       crab::crab_string_os os;
       os << "(type checking) " << v << " must be an array variable in " << s;
@@ -271,7 +271,7 @@ class type_checker_visitor
 
   // v1 is array type and v2 is a scalar type consistent with v1
   void check_array_and_scalar_type(const variable_t &v1, const variable_t &v2,
-                                   statement_t &s) {
+                                   const statement_t &s) {
     if (v1.get_type().is_bool_array()) {
       if (v2.get_type().is_bool())
         return;
@@ -296,7 +296,7 @@ class type_checker_visitor
 public:
   type_checker_visitor() {}
 
-  virtual void visit(bin_op_t &s) override {
+  virtual void visit(const bin_op_t &s) override {
     const variable_t &lhs = s.lhs();
     const lin_exp_t &op1 = s.left();
     const lin_exp_t &op2 = s.right();
@@ -322,7 +322,7 @@ public:
     }
   }
 
-  virtual void visit(assign_t &s) override {
+  virtual void visit(const assign_t &s) override {
     const variable_t &lhs = s.lhs();
     const lin_exp_t &rhs = s.rhs();
 
@@ -336,7 +336,7 @@ public:
     }
   }
 
-  virtual void visit(assume_t &s) override {
+  virtual void visit(const assume_t &s) override {
     bool first = true;
     const variable_t *first_var = nullptr;
     for (auto const &v : s.constraint().variables()) {
@@ -352,7 +352,7 @@ public:
     }
   }
 
-  virtual void visit(assert_t &s) override {
+  virtual void visit(const assert_t &s) override {
     bool first = true;
     const variable_t *first_var;
     for (auto const &v : s.constraint().variables()) {
@@ -368,7 +368,7 @@ public:
     }
   }
 
-  virtual void visit(select_t &s) override {
+  virtual void visit(const select_t &s) override {
     check_num(s.lhs(), "lhs must be integer or real", s);
     check_varname(s.lhs());
     for (auto const &v : s.left().variables()) {
@@ -397,7 +397,7 @@ public:
     }
   }
 
-  virtual void visit(int_cast_t &s) override {
+  virtual void visit(const int_cast_t &s) override {
     const variable_t &src = s.src();
     const variable_t &dst = s.dst();
 
@@ -431,11 +431,11 @@ public:
     }
   }
 
-  virtual void visit(havoc_t &) override {}
+  virtual void visit(const havoc_t &) override {}
 
-  virtual void visit(unreach_t &) override {}
+  virtual void visit(const unreach_t &) override {}
 
-  virtual void visit(bool_bin_op_t &s) override {
+  virtual void visit(const bool_bin_op_t &s) override {
     check_varname(s.lhs());
     check_varname(s.left());
     check_varname(s.right());
@@ -444,7 +444,7 @@ public:
     check_bool(s.right(), "second operand must be boolean", s);
   };
 
-  virtual void visit(bool_assign_cst_t &s) override {
+  virtual void visit(const bool_assign_cst_t &s) override {
     check_bool(s.lhs(), "lhs must be boolean", s);
     check_varname(s.lhs());
     bool first = true;
@@ -477,24 +477,24 @@ public:
     }
   };
 
-  virtual void visit(bool_assign_var_t &s) override {
+  virtual void visit(const bool_assign_var_t &s) override {
     check_bool(s.lhs(), "lhs must be boolean", s);
     check_bool(s.rhs(), "rhs must be boolean", s);
     check_varname(s.lhs());
     check_varname(s.rhs());
   };
 
-  virtual void visit(bool_assume_t &s) override {
+  virtual void visit(const bool_assume_t &s) override {
     check_bool(s.cond(), "condition must be boolean", s);
     check_varname(s.cond());
   };
 
-  virtual void visit(bool_assert_t &s) override {
+  virtual void visit(const bool_assert_t &s) override {
     check_bool(s.cond(), "condition must be boolean", s);
     check_varname(s.cond());
   };
 
-  virtual void visit(bool_select_t &s) override {
+  virtual void visit(const bool_select_t &s) override {
     check_bool(s.lhs(), "lhs must be boolean", s);
     check_bool(s.lhs(), "condition must be boolean", s);
     check_bool(s.left(), "first operand must be boolean", s);
@@ -504,7 +504,7 @@ public:
     check_varname(s.right());
   };
 
-  virtual void visit(arr_init_t &s) override {
+  virtual void visit(const arr_init_t &s) override {
     // TODO: check that e_sz is the same number that v's bitwidth
     const variable_t &a = s.array();
     const lin_exp_t &e_sz = s.elem_size();
@@ -527,7 +527,7 @@ public:
     }
   }
 
-  virtual void visit(arr_store_t &s) override {
+  virtual void visit(const arr_store_t &s) override {
     // TODO: check that e_sz is the same number that v's bitwidth
     const variable_t &a = s.array();
     check_is_array(a, s);
@@ -563,7 +563,7 @@ public:
     }
   }
 
-  virtual void visit(arr_load_t &s) override {
+  virtual void visit(const arr_load_t &s) override {
     // TODO: check that e_sz is the same number that lhs's bitwidth
     const variable_t &a = s.array();
     const lin_exp_t &e_sz = s.elem_size();
@@ -580,7 +580,7 @@ public:
     check_array_and_scalar_type(a, lhs, s);
   }
 
-  virtual void visit(arr_assign_t &s) override {
+  virtual void visit(const arr_assign_t &s) override {
     const variable_t &lhs = s.lhs();
     const variable_t &rhs = s.rhs();
     check_is_array(lhs, s);
@@ -590,7 +590,7 @@ public:
     check_same_type(lhs, rhs, "array assign variables must have same type", s);
   }
 
-  virtual void visit(callsite_t &s) override {
+  virtual void visit(const callsite_t &s) override {
     // The type consistency with the callee parameters is done
     // elsewhere.
     for (const variable_t &v : s.get_lhs()) {
@@ -601,7 +601,7 @@ public:
     }
   }
 
-  virtual void visit(intrinsic_t &s) override {
+  virtual void visit(const intrinsic_t &s) override {
     for (const variable_t &v : s.get_lhs()) {
       check_varname(v);
     }
@@ -612,16 +612,16 @@ public:
     }
   }
 
-  virtual void visit(region_init_t &s) override { check_region(s.region(), s); }
+  virtual void visit(const region_init_t &s) override { check_region(s.region(), s); }
 
-  virtual void visit(region_copy_t &s) override {
+  virtual void visit(const region_copy_t &s) override {
     check_region(s.lhs_region(), s);
     check_region(s.rhs_region(), s);
     check_same_type(s.lhs_region(), s.rhs_region(),
                     "region_copy must have same types", s);
   }
 
-  virtual void visit(region_cast_t &s) override {
+  virtual void visit(const region_cast_t &s) override {
     check_region(s.src(), s);
     check_region(s.dst(), s);
     if (!(s.src().get_type().is_unknown_region() ^
@@ -634,38 +634,38 @@ public:
     }
   }
 
-  virtual void visit(make_ref_t &s) override {
+  virtual void visit(const make_ref_t &s) override {
     check_region(s.region(), s);
     check_ref(s.lhs(), "", s);
   }
 
-  virtual void visit(remove_ref_t &s) override {
+  virtual void visit(const remove_ref_t &s) override {
     check_region(s.region(), s);
     check_ref(s.ref(), "", s);
   }
 
-  virtual void visit(load_from_ref_t &s) override {
+  virtual void visit(const load_from_ref_t &s) override {
     check_region(s.region(), s);
     check_ref(s.ref(), "", s);
     check_region_consistent_with_data(s.region(), s.lhs().get_type(), s);
   }
 
-  virtual void visit(store_to_ref_t &s) override {
+  virtual void visit(const store_to_ref_t &s) override {
     check_region(s.region(), s);
     check_ref(s.ref(), "", s);
     check_region_consistent_with_data(s.region(), s.val().get_type(), s);
   }
 
-  virtual void visit(gep_ref_t &s) override {
+  virtual void visit(const gep_ref_t &s) override {
     check_region(s.lhs_region(), s);
     check_region(s.rhs_region(), s);
     check_ref(s.lhs(), "", s);
     check_ref(s.rhs(), "", s);
   }
 
-  virtual void visit(assume_ref_t &s) override {}
-  virtual void visit(assert_ref_t &s) override {}
-  virtual void visit(select_ref_t &s) override {
+  virtual void visit(const assume_ref_t &s) override {}
+  virtual void visit(const assert_ref_t &s) override {}
+  virtual void visit(const select_ref_t &s) override {
     // TODO: check region operands
     check_ref(s.lhs_ref(), "lhs must be reference", s);
     check_bool(s.cond(), "condition must be boolean", s);
@@ -677,12 +677,12 @@ public:
     if (s.right_ref().is_variable())
       check_varname(s.right_ref().get_variable());
   }
-  virtual void visit(int_to_ref_t &s) override {
+  virtual void visit(const int_to_ref_t &s) override {
     check_region(s.region(), s);
     check_ref(s.ref_var(), "", s);
     check_num(s.int_var(), "first input must be a number", s);
   }
-  virtual void visit(ref_to_int_t &s) override {
+  virtual void visit(const ref_to_int_t &s) override {
     check_region(s.region(), s);
     check_ref(s.ref_var(), "", s);
     check_num(s.int_var(), "first input must be a number", s);

--- a/include/crab/cg/cg.hpp
+++ b/include/crab/cg/cg.hpp
@@ -96,7 +96,8 @@ template <typename CFG> class call_graph {
   using number_t = typename CFG::number_t;
   using basic_block_label_t = typename CFG::basic_block_label_t;
   using stmt_visitor_t =
-      crab::cfg::statement_visitor<basic_block_label_t, number_t, varname_t>;
+      crab::cfg::const_statement_visitor<basic_block_label_t, number_t,
+                                         varname_t>;
   using callsite_or_fdecl_t = crab::cfg::callsite_or_fdecl<CFG>;
   // map a callsite or function declaration to a dense vertex id
   using vertex_map_t = crab::cfg::callsite_or_fdecl_map<CFG, std::size_t>;
@@ -135,7 +136,7 @@ private:
     mk_edge_vis(call_graph &parent, const fdecl_t &from)
         : m_parent(parent), m_from(from) {}
 
-    virtual void visit(callsite_t &cs) override {
+    virtual void visit(const callsite_t &cs) override {
       auto &vertex_map = m_parent.m_vertex_map;
       auto it_from = vertex_map.find(&m_from);
       auto it_to = vertex_map.find(&cs);

--- a/include/crab/checkers/assertion.hpp
+++ b/include/crab/checkers/assertion.hpp
@@ -63,7 +63,7 @@ public:
     return false;
   }
 
-  virtual void check(assert_t &s) override {
+  virtual void check(const assert_t &s) override {
     if (!this->m_abs_tr) {
       return;
     }
@@ -159,7 +159,7 @@ public:
     s.accept(&*this->m_abs_tr); // propagate invariants to the next stmt
   }
 
-  virtual void check(bool_assert_t &s) override {
+  virtual void check(const bool_assert_t &s) override {
     if (!this->m_abs_tr) {
       return;
     }
@@ -200,7 +200,7 @@ public:
     s.accept(&*this->m_abs_tr); // propagate invariants to the next stmt
   }
 
-  virtual void check(assert_ref_t &s) override {
+  virtual void check(const assert_ref_t &s) override {
     if (!this->m_abs_tr) {
       return;
     }

--- a/include/crab/checkers/base_property.hpp
+++ b/include/crab/checkers/base_property.hpp
@@ -176,7 +176,7 @@ public:
 
 template <typename Analyzer>
 class property_checker
-    : public crab::cfg::statement_visitor<
+    : public crab::cfg::const_statement_visitor<
           typename Analyzer::basic_block_label_t, typename Analyzer::number_t,
           typename Analyzer::varname_t> {
 public:
@@ -320,199 +320,199 @@ protected:
     }
   }
 
-  virtual void check(assert_t &s) {
+  virtual void check(const assert_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bin_op_t &s) {
+  virtual void check(const bin_op_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(assign_t &s) {
+  virtual void check(const assign_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(assume_t &s) {
+  virtual void check(const assume_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(select_t &s) {
+  virtual void check(const select_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(int_cast_t &s) {
+  virtual void check(const int_cast_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(havoc_t &s) {
+  virtual void check(const havoc_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(unreach_t &s) {
+  virtual void check(const unreach_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(callsite_t &s) {
+  virtual void check(const callsite_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(intrinsic_t &s) {
+  virtual void check(const intrinsic_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(arr_init_t &s) {
+  virtual void check(const arr_init_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(arr_assign_t &s) {
+  virtual void check(const arr_assign_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(arr_store_t &s) {
+  virtual void check(const arr_store_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(arr_load_t &s) {
+  virtual void check(const arr_load_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(region_init_t &s) {
+  virtual void check(const region_init_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(region_copy_t &s) {
+  virtual void check(const region_copy_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(region_cast_t &s) {
+  virtual void check(const region_cast_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
   
-  virtual void check(make_ref_t &s) {
+  virtual void check(const make_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(remove_ref_t &s) {
+  virtual void check(const remove_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
   
-  virtual void check(load_from_ref_t &s) {
+  virtual void check(const load_from_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(store_to_ref_t &s) {
+  virtual void check(const store_to_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(gep_ref_t &s) {
+  virtual void check(const gep_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(assume_ref_t &s) {
+  virtual void check(const assume_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(assert_ref_t &s) {
+  virtual void check(const assert_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(select_ref_t &s) {
+  virtual void check(const select_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(int_to_ref_t &s) {
+  virtual void check(const int_to_ref_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(ref_to_int_t &s) {
+  virtual void check(const ref_to_int_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_assert_t &s) {
+  virtual void check(const bool_assert_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_bin_op_t &s) {
+  virtual void check(const bool_bin_op_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_assign_cst_t &s) {
+  virtual void check(const bool_assign_cst_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_assign_var_t &s) {
+  virtual void check(const bool_assign_var_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_assume_t &s) {
+  virtual void check(const bool_assume_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
   }
 
-  virtual void check(bool_select_t &s) {
+  virtual void check(const bool_select_t &s) {
     if (!this->m_abs_tr)
       return;
     s.accept(&*this->m_abs_tr); // propagate m_inv to the next stmt
@@ -520,39 +520,39 @@ protected:
 
 public:
   /* Visitor API */
-  virtual void visit(bin_op_t &s) override { check(s); }
-  virtual void visit(assign_t &s) override { check(s); }
-  virtual void visit(assume_t &s) override { check(s); }
-  virtual void visit(select_t &s) override { check(s); }
-  virtual void visit(assert_t &s) override { check(s); }
-  virtual void visit(int_cast_t &s) override { check(s); }
-  virtual void visit(havoc_t &s) override { check(s); }
-  virtual void visit(unreach_t &s) override { check(s); }
-  virtual void visit(callsite_t &s) override { check(s); }
-  virtual void visit(intrinsic_t &s) override { check(s); }
-  virtual void visit(arr_init_t &s) override { check(s); }
-  virtual void visit(arr_assign_t &s) override { check(s); }
-  virtual void visit(arr_store_t &s) override { check(s); }
-  virtual void visit(arr_load_t &s) override { check(s); }
-  virtual void visit(region_init_t &s) override { check(s); }
-  virtual void visit(region_copy_t &s) override { check(s); }
-  virtual void visit(region_cast_t &s) override { check(s); }  
-  virtual void visit(make_ref_t &s) override { check(s); }
-  virtual void visit(remove_ref_t &s) override { check(s); }  
-  virtual void visit(load_from_ref_t &s) override { check(s); }
-  virtual void visit(store_to_ref_t &s) override { check(s); }
-  virtual void visit(gep_ref_t &s) override { check(s); }
-  virtual void visit(assume_ref_t &s) override { check(s); }
-  virtual void visit(assert_ref_t &s) override { check(s); }
-  virtual void visit(select_ref_t &s) override { check(s); }
-  virtual void visit(int_to_ref_t &s) override { check(s); }
-  virtual void visit(ref_to_int_t &s) override { check(s); }
-  virtual void visit(bool_bin_op_t &s) override { check(s); }
-  virtual void visit(bool_assign_cst_t &s) override { check(s); }
-  virtual void visit(bool_assign_var_t &s) override { check(s); }
-  virtual void visit(bool_assume_t &s) override { check(s); }
-  virtual void visit(bool_select_t &s) override { check(s); }
-  virtual void visit(bool_assert_t &s) override { check(s); }
+  virtual void visit(const bin_op_t &s) override { check(s); }
+  virtual void visit(const assign_t &s) override { check(s); }
+  virtual void visit(const assume_t &s) override { check(s); }
+  virtual void visit(const select_t &s) override { check(s); }
+  virtual void visit(const assert_t &s) override { check(s); }
+  virtual void visit(const int_cast_t &s) override { check(s); }
+  virtual void visit(const havoc_t &s) override { check(s); }
+  virtual void visit(const unreach_t &s) override { check(s); }
+  virtual void visit(const callsite_t &s) override { check(s); }
+  virtual void visit(const intrinsic_t &s) override { check(s); }
+  virtual void visit(const arr_init_t &s) override { check(s); }
+  virtual void visit(const arr_assign_t &s) override { check(s); }
+  virtual void visit(const arr_store_t &s) override { check(s); }
+  virtual void visit(const arr_load_t &s) override { check(s); }
+  virtual void visit(const region_init_t &s) override { check(s); }
+  virtual void visit(const region_copy_t &s) override { check(s); }
+  virtual void visit(const region_cast_t &s) override { check(s); }  
+  virtual void visit(const make_ref_t &s) override { check(s); }
+  virtual void visit(const remove_ref_t &s) override { check(s); }  
+  virtual void visit(const load_from_ref_t &s) override { check(s); }
+  virtual void visit(const store_to_ref_t &s) override { check(s); }
+  virtual void visit(const gep_ref_t &s) override { check(s); }
+  virtual void visit(const assume_ref_t &s) override { check(s); }
+  virtual void visit(const assert_ref_t &s) override { check(s); }
+  virtual void visit(const select_ref_t &s) override { check(s); }
+  virtual void visit(const int_to_ref_t &s) override { check(s); }
+  virtual void visit(const ref_to_int_t &s) override { check(s); }
+  virtual void visit(const bool_bin_op_t &s) override { check(s); }
+  virtual void visit(const bool_assign_cst_t &s) override { check(s); }
+  virtual void visit(const bool_assign_var_t &s) override { check(s); }
+  virtual void visit(const bool_assume_t &s) override { check(s); }
+  virtual void visit(const bool_select_t &s) override { check(s); }
+  virtual void visit(const bool_assert_t &s) override { check(s); }
 
   property_checker(int verbose) : m_abs_tr(nullptr), m_verbose(verbose) {}
 

--- a/include/crab/checkers/checker.hpp
+++ b/include/crab/checkers/checker.hpp
@@ -88,7 +88,7 @@ public:
     m_analyzer.get_safe_assertions(safe_assertions);
     abs_tr_t &abs_tr = m_analyzer.get_abs_transformer();
 
-    for (auto &bb : cfg) {
+    for (auto const &bb : cfg) {
       for (auto checker : this->m_checkers) {
         if (checker->is_interesting(bb)) {
           abs_dom_t inv = m_analyzer[bb.label()];
@@ -96,7 +96,7 @@ public:
           // propagate forward the invariants from the block entry
           // while checking the property
           checker->set(&abs_tr, safe_assertions);
-          for (auto &stmt : bb) {
+          for (auto const &stmt : bb) {
             stmt.accept(&*checker);
           }
         }
@@ -134,7 +134,7 @@ public:
     for (auto &v : boost::make_iterator_range(vertices(cg))) {
       cfg_t cfg = v.get_cfg();
 
-      for (auto &bb : cfg) {
+      for (auto const &bb : cfg) {
         // the forward+backward analyzer only works for
         // intra-procedural analysis.
         std::set<const statement_t *> safe_assertions;
@@ -144,7 +144,7 @@ public:
           // propagate forward the invariants from the block entry
           // while checking the property
           checker->set(&abs_tr, safe_assertions);
-          for (auto &stmt : bb) {
+          for (auto const &stmt : bb) {
             stmt.accept(&*checker);
           }
         }

--- a/include/crab/checkers/div_zero.hpp
+++ b/include/crab/checkers/div_zero.hpp
@@ -34,7 +34,7 @@ public:
     return "integer division by zero checker";
   }
 
-  void check(bin_op_t &s) override {
+  void check(const bin_op_t &s) override {
     if (!this->m_abs_tr)
       return;
 


### PR DESCRIPTION
statement_visitor's visit methods take non-const references, so a read-only visitor could not be applied to a const statement. Add const_statement_visitor, which takes const references, together with statement::accept(const_statement_visitor*) const and const accept overloads on basic_block and basic_block_rev.

Every visitor in Crab turned out to be read-only, so all of them move to the new visitor: the CFG-to-JSON writer (dropping a const_cast), the type checker, the call graph builder, the assertion crawler, the abstract transformers and the property checkers.

statement_visitor is unchanged and still public.