### PR TITLE
Fix/bitwidth type consistency

### DIFF
--- a/include/crab/cfg/type_checker.hpp
+++ b/include/crab/cfg/type_checker.hpp
@@ -293,6 +293,32 @@ class type_checker_visitor
     CRAB_ERROR(os.str());
   }
 
+  // Check that the element size of an array access (in bytes) agrees with the
+  // bitwidth of the scalar being loaded or stored.
+  //
+  // Only integer arrays are constrained here: booleans are accessed using
+  // whatever element size the client chooses (their bitwidth is always 1) and
+  // reals have no bitwidth. The check is skipped when the element size is not
+  // a constant, since then it is only known at runtime.
+  void check_array_elem_size(const variable_t &a, const lin_exp_t &e_sz,
+                             const variable_t &v, const statement_t &s) {
+    if (!a.get_type().is_integer_array() || !v.get_type().is_integer()) {
+      return;
+    }
+    if (!e_sz.is_constant()) {
+      return;
+    }
+    unsigned bitwidth = v.get_type().get_integer_bitwidth();
+    if (e_sz.constant() * N(static_cast<int64_t>(8)) !=
+        N(static_cast<int64_t>(bitwidth))) {
+      crab::crab_string_os os;
+      os << "(type checking) the element size of " << a << " ("
+         << e_sz.constant() << " bytes) is not consistent with the bitwidth of "
+         << v << " (" << bitwidth << " bits) in " << s;
+      CRAB_ERROR(os.str());
+    }
+  }
+
 public:
   type_checker_visitor() {}
 
@@ -505,7 +531,6 @@ public:
   };
 
   virtual void visit(const arr_init_t &s) override {
-    // TODO: check that e_sz is the same number that v's bitwidth
     const variable_t &a = s.array();
     const lin_exp_t &e_sz = s.elem_size();
     const lin_exp_t &lb = s.lb_index();
@@ -524,11 +549,11 @@ public:
     if (boost::optional<variable_t> vv = v.get_variable()) {
       check_varname(*vv);
       check_array_and_scalar_type(a, *vv, s);
+      check_array_elem_size(a, e_sz, *vv, s);
     }
   }
 
   virtual void visit(const arr_store_t &s) override {
-    // TODO: check that e_sz is the same number that v's bitwidth
     const variable_t &a = s.array();
     check_is_array(a, s);
     check_varname(a);
@@ -560,11 +585,11 @@ public:
     if (boost::optional<variable_t> vv = v.get_variable()) {
       check_varname(*vv);
       check_array_and_scalar_type(a, *vv, s);
+      check_array_elem_size(a, e_sz, *vv, s);
     }
   }
 
   virtual void visit(const arr_load_t &s) override {
-    // TODO: check that e_sz is the same number that lhs's bitwidth
     const variable_t &a = s.array();
     const lin_exp_t &e_sz = s.elem_size();
     const variable_t &lhs = s.lhs();
@@ -578,6 +603,7 @@ public:
     }
     check_num_or_var(e_sz, "array element size must be number or variable", s);
     check_array_and_scalar_type(a, lhs, s);
+    check_array_elem_size(a, e_sz, lhs, s);
   }
 
   virtual void visit(const arr_assign_t &s) override {

--- a/include/crab/domains/region/ghost_variables.hpp
+++ b/include/crab/domains/region/ghost_variables.hpp
@@ -257,12 +257,6 @@ public:
         bitwidth = 32;
       } else if (vty.is_real_region()) {
         ty = REAL_TYPE;
-      } else if (vty.is_bool_array_region()) {
-        ty = ARR_BOOL_TYPE;
-      } else if (vty.is_int_array_region()) {
-        ty = ARR_INT_TYPE;
-      } else if (vty.is_real_array_region()) {
-        ty = ARR_REAL_TYPE;
       } else {
         assert(false);
         CRAB_ERROR("make_ghost_variable: unreachable");

--- a/include/crab/domains/region_domain.hpp
+++ b/include/crab/domains/region_domain.hpp
@@ -628,13 +628,6 @@ private:
     }
   }
 
-  static void ERROR_IF_ARRAY_REGION(const variable_t &v, unsigned line) {
-    if (v.get_type().is_array_region()) {
-      CRAB_ERROR(v, ":", v.get_type(), " cannot contain an array at line ",
-                 line);
-    }
-  }
-
   static void ERROR_IF_NOT_REF(const variable_t &v, unsigned line) {
     if (!v.get_type().is_reference()) {
       CRAB_ERROR(v, ":", v.get_type(), " is not a reference at line ", line);
@@ -1078,8 +1071,6 @@ public:
         m_base_dom.assign_bool_var(x_gvars.get_var(), y_gvars.get_var(), false);
       } else if (dyn_ty.is_integer_region() || dyn_ty.is_real_region()) {
         m_base_dom.assign(x_gvars.get_var(), y_gvars.get_var());
-      } else if (dyn_ty.is_array_region()) {
-        m_base_dom.array_assign(x_gvars.get_var(), y_gvars.get_var());
       }
     };
 
@@ -1223,7 +1214,6 @@ public:
     REGION_DOMAIN_SCOPED_STATS(".ref_load");
 
     ERROR_IF_NOT_REGION(rgn, __LINE__);
-    ERROR_IF_ARRAY_REGION(rgn, __LINE__);
     ERROR_IF_NOT_REF(ref, __LINE__);
     if ((rgn.get_type().is_bool_region() && !res.get_type().is_bool()) ||
         (rgn.get_type().is_integer_region() && !res.get_type().is_integer()) ||
@@ -1341,7 +1331,6 @@ public:
     REGION_DOMAIN_SCOPED_STATS(".ref_store");
 
     ERROR_IF_NOT_REGION(rgn, __LINE__);
-    ERROR_IF_ARRAY_REGION(rgn, __LINE__);
     ERROR_IF_NOT_REF(ref, __LINE__);
     if ((rgn.get_type().is_bool_region() && !val.get_type().is_bool()) ||
         (rgn.get_type().is_integer_region() && !val.get_type().is_integer()) ||

--- a/include/crab/types/linear_constraints.hpp
+++ b/include/crab/types/linear_constraints.hpp
@@ -331,7 +331,7 @@ public:
   }
 
   bool is_well_typed() const {
-    crab::variable_type vt(crab::UNK_TYPE, 0);
+    crab::variable_type vt(crab::UNK_TYPE);
     for (const_iterator it = begin(), et = end(); it != et; ++it) {
       variable_t v = it->second;
       if (it == begin()) {

--- a/include/crab/types/variable.hpp
+++ b/include/crab/types/variable.hpp
@@ -209,7 +209,7 @@ public:
       o << "region(bool)";
       break;
     case REG_INT_TYPE:
-      o << "region(int)";
+      o << "region(int" << m_bitwidth << ")";
       break;
     case REG_REAL_TYPE:
       o << "region(real)";
@@ -217,8 +217,8 @@ public:
     case REG_REF_TYPE:
       o << "region(ref)";
       break;
-    default:
-      o << "unknown";
+    case UNK_TYPE:
+      o << "untyped";
       break;
     }
   }

--- a/include/crab/types/variable.hpp
+++ b/include/crab/types/variable.hpp
@@ -66,6 +66,13 @@ public:
 
     if (m_kind == BOOL_TYPE) {
       m_bitwidth = 1;
+    } else if (m_kind != INT_TYPE && m_kind != REG_INT_TYPE) {
+      // Only integers and integer regions have a bitwidth. A width passed for
+      // any other kind is meaningless -- in particular, array element widths
+      // come from the elem_size operand of each array access, not from the
+      // array type -- so normalize it away and keep the representation
+      // canonical.
+      m_bitwidth = 0;
     }
   }
 
@@ -128,7 +135,9 @@ public:
     return m_kind == INT_TYPE && m_bitwidth == bitwidth;
   }
   unsigned get_integer_bitwidth() const {
-    assert(m_kind == INT_TYPE);
+    if (m_kind != INT_TYPE) {
+      CRAB_ERROR("get_integer_bitwidth called on a non-integer type");
+    }
     return m_bitwidth;
   }
   bool is_real() const { return m_kind == REAL_TYPE; }
@@ -148,7 +157,10 @@ public:
   bool is_bool_region() const { return m_kind == REG_BOOL_TYPE; }
   bool is_integer_region() const { return m_kind == REG_INT_TYPE; }
   unsigned get_integer_region_bitwidth() const {
-    assert(m_kind == REG_INT_TYPE);
+    if (m_kind != REG_INT_TYPE) {
+      CRAB_ERROR(
+          "get_integer_region_bitwidth called on a non-integer-region type");
+    }
     return m_bitwidth;
   }
   bool is_real_region() const { return m_kind == REG_REAL_TYPE; }
@@ -272,7 +284,7 @@ private:
 public:
   /* ========== Begin internal API  ============= */
   /* Call this constructor only from abstract domains */
-  explicit variable(const VariableName &n) : _n(n), m_ty(crab::UNK_TYPE, 0) {}
+  explicit variable(const VariableName &n) : _n(n), m_ty(crab::UNK_TYPE) {}
 
   /* Call this constructor only from abstract domains */
   variable(const VariableName &n, variable_type_kind ty_kind)

--- a/include/crab/types/variable.hpp
+++ b/include/crab/types/variable.hpp
@@ -18,17 +18,12 @@ enum variable_type_kind {
   ARR_BOOL_TYPE,
   ARR_INT_TYPE,
   ARR_REAL_TYPE,
-  // region types: a region can contain either a scalar or an array of
-  // a non-reference type
-  REG_UNKNOWN_TYPE, // any REG_X unifies with this
+  // region types: a region can only contain a scalar
+  REG_UNKNOWN_TYPE, // any REG_X_TYPE unifies with REG_UNKNOWN_TYPE
   REG_BOOL_TYPE,
   REG_INT_TYPE,
   REG_REAL_TYPE,
   REG_REF_TYPE,
-  //
-  REG_ARR_BOOL_TYPE,
-  REG_ARR_INT_TYPE,
-  REG_ARR_REAL_TYPE,
 
   // unknown type
   UNK_TYPE
@@ -84,13 +79,7 @@ public:
     } else if (ty.is_real()) {
       return variable_type(variable_type_kind::REG_REAL_TYPE);
     } else if (ty.is_reference()) {
-      return variable_type(variable_type_kind::REG_REF_TYPE);      
-    } else if (ty.is_bool_array()) {
-      return variable_type(variable_type_kind::REG_ARR_BOOL_TYPE);      
-    } else if (ty.is_real_array()) {
-      return variable_type(variable_type_kind::REG_ARR_REAL_TYPE);            
-    } else if (ty.is_integer_array()) {
-      return variable_type(variable_type_kind::REG_ARR_INT_TYPE);                  
+      return variable_type(variable_type_kind::REG_REF_TYPE);
     } else if (!ty.is_typed()) {
       return variable_type(variable_type_kind::REG_UNKNOWN_TYPE);
     } else {
@@ -165,19 +154,12 @@ public:
   }
   bool is_real_region() const { return m_kind == REG_REAL_TYPE; }
   bool is_reference_region() const { return m_kind == REG_REF_TYPE; }
-  bool is_bool_array_region() const { return m_kind == REG_ARR_BOOL_TYPE; }
-  bool is_int_array_region() const { return m_kind == REG_ARR_INT_TYPE; }
-  bool is_real_array_region() const { return m_kind == REG_ARR_REAL_TYPE; }
   bool is_region() const {
-    return is_unknown_region() || is_scalar_region() || is_array_region();
+    return is_unknown_region() || is_scalar_region();
   }
   bool is_scalar_region() const {
     return is_bool_region() || is_integer_region() || is_real_region() ||
            is_reference_region();
-  }
-  bool is_array_region() const {
-    return is_bool_array_region() || is_int_array_region() ||
-           is_real_array_region();
   }
 
   variable_type get_region_content_type() const {
@@ -190,12 +172,6 @@ public:
       return variable_type(variable_type_kind::REAL_TYPE);
     } else if (is_reference_region()) {
       return variable_type(variable_type_kind::REF_TYPE);
-    } else if (is_int_array_region()) {
-      return variable_type(variable_type_kind::ARR_INT_TYPE);
-    } else if (is_real_array_region()) {
-      return variable_type(variable_type_kind::ARR_REAL_TYPE);      
-    } else if (is_bool_array_region()) {
-      return variable_type(variable_type_kind::ARR_BOOL_TYPE);            
     } else if (is_unknown_region()) {
       return variable_type(variable_type_kind::UNK_TYPE);            
     } else {
@@ -240,15 +216,6 @@ public:
       break;
     case REG_REF_TYPE:
       o << "region(ref)";
-      break;
-    case REG_ARR_BOOL_TYPE:
-      o << "region(arr(bool))";
-      break;
-    case REG_ARR_INT_TYPE:
-      o << "region(arr(int))";
-      break;
-    case REG_ARR_REAL_TYPE:
-      o << "region(arr(real))";
       break;
     default:
       o << "unknown";

--- a/include/crab/types/variable_to_json.hpp
+++ b/include/crab/types/variable_to_json.hpp
@@ -48,12 +48,6 @@ inline void write(writer &w, const crab::variable_type &ty) {
     w.kv_string("kind", "real_region");
   } else if (ty.is_reference_region()) {
     w.kv_string("kind", "ref_region");
-  } else if (ty.is_bool_array_region()) {
-    w.kv_string("kind", "bool_array_region");
-  } else if (ty.is_int_array_region()) {
-    w.kv_string("kind", "int_array_region");
-  } else if (ty.is_real_array_region()) {
-    w.kv_string("kind", "real_array_region");
   } else {
     w.kv_string("kind", "unknown");
   }

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -149,12 +149,6 @@ void type_value::write(crab::crab_os &o) const {
       o << "region(real)";
     } else if (ty.is_reference_region()) {
       o << "region(ref)";
-    } else if (ty.is_bool_array_region()) {
-      o << "region(arr(bool))";
-    } else if (ty.is_int_array_region()) {
-      o << "region(arr(int))";
-    } else if (ty.is_real_array_region()) {
-      o << "region(arr(real))";
     } else {
       // this shouldn't happen
       o << "top";

--- a/lib/types.cpp
+++ b/lib/types.cpp
@@ -124,35 +124,8 @@ void type_value::write(crab::crab_os &o) const {
   } else if (is_top()) {
     o << "top";
   } else {
-    variable_type ty = get();
-    if (ty.is_bool()) {
-      o << "bool";
-    } else if (ty.is_integer()) {
-	o << "int" << ty.get_integer_bitwidth();
-    } else if (ty.is_real()) {
-      o << "real";
-    } else if (ty.is_reference()) {
-      o << "ref";
-    } else if (ty.is_bool_array()) {
-      o << "arr(bool)";
-    } else if (ty.is_integer_array()) {
-      o << "arr(int)";
-    } else if (ty.is_real_array()) {
-      o << "arr(real)";
-    } else if (ty.is_unknown_region()) {
-      o << "region(unknown)";
-    } else if (ty.is_bool_region()) {
-      o << "region(bool)";
-    } else if (ty.is_integer_region()) {
-      o << "region(int" << ty.get_integer_region_bitwidth() << ")";
-    } else if (ty.is_real_region()) {
-      o << "region(real)";
-    } else if (ty.is_reference_region()) {
-      o << "region(ref)";
-    } else {
-      // this shouldn't happen
-      o << "top";
-    }
+    // variable_type::write is the single definition of how a type is printed.
+    get().write(o);
   }  
 }
   

--- a/tests/cfg/cfg_to_json.cc
+++ b/tests/cfg/cfg_to_json.cc
@@ -202,7 +202,7 @@ void test_writer_scalars() {
 void test_variable_json() {
   variable_factory_t vfac;
   z_var x(vfac["x"], crab::INT_TYPE, 32);
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
   z_var a(vfac["a"], crab::ARR_INT_TYPE);
 
   BOOST_TEST_EQ(to_json(x),
@@ -392,8 +392,8 @@ void test_cfg_json_statements() {
   z_var x(vfac["x"], crab::INT_TYPE, 32);
   z_var y(vfac["y"], crab::INT_TYPE, 32);
   z_var w(vfac["w"], crab::INT_TYPE, 8);
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
   z_var a(vfac["a"], crab::ARR_INT_TYPE);
   z_var a2(vfac["a2"], crab::ARR_INT_TYPE);
 
@@ -529,7 +529,7 @@ void test_cfg_json_reference_statements() {
   z_var r(vfac["r"], crab::REF_TYPE);
   z_var v(vfac["v"], crab::INT_TYPE, 32);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
-  z_var c(vfac["c"], crab::BOOL_TYPE, 1);
+  z_var c(vfac["c"], crab::BOOL_TYPE);
   z_var_or_cst_t size4(ikos::z_number(4), crab::variable_type(crab::INT_TYPE, 32));
 
   z_cfg_t cfg("entry");

--- a/tests/cg/cg_ref_bitwidth.cc
+++ b/tests/cg/cg_ref_bitwidth.cc
@@ -48,8 +48,8 @@ static std::unique_ptr<z_cfg_t> callee(variable_factory_t &vfac) {
 // are equal under variable_type::operator== but hashed differently before
 // the fix.
 static std::unique_ptr<z_cfg_t> mk_main(variable_factory_t &vfac) {
-  z_var a(vfac["a"], crab::REF_TYPE, 32);
-  z_var b(vfac["b"], crab::REF_TYPE, 32);
+  z_var a(vfac["a"], crab::REF_TYPE);
+  z_var b(vfac["b"], crab::REF_TYPE);
   std::vector<z_var> inputs, outputs;
   function_decl<z_number, varname_t> decl("main", inputs, outputs);
   auto cfg = std::make_unique<z_cfg_t>("entry", "exit", decl);
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     // (1) Directly exercise the invariant that regressed: two reference
     //     types that compare equal must hash equally.
     z_var ref0(vfac["ref0"], crab::REF_TYPE);       // bitwidth 0
-    z_var ref32(vfac["ref32"], crab::REF_TYPE, 32); // bitwidth 32
+    z_var ref32(vfac["ref32"], crab::REF_TYPE); // bitwidth 32
     const auto t0 = ref0.get_type();
     const auto t32 = ref32.get_type();
     if (!(t0 == t32)) {

--- a/tests/domains/array_adaptive1.cc
+++ b/tests/domains/array_adaptive1.cc
@@ -184,11 +184,11 @@ std::unique_ptr<z_cfg_t> prog4b(variable_factory_t &vfac) {
   z_var i(vfac["i"], crab::INT_TYPE, 8);
   z_var a(vfac["A"], crab::ARR_BOOL_TYPE);
   z_var b(vfac["B"], crab::ARR_BOOL_TYPE);
-  z_var tt(vfac["TRUE"], crab::BOOL_TYPE, 1);
-  z_var ff(vfac["FALSE"], crab::BOOL_TYPE, 1);
+  z_var tt(vfac["TRUE"], crab::BOOL_TYPE);
+  z_var ff(vfac["FALSE"], crab::BOOL_TYPE);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 8);
-  z_var tmp5(vfac["tmp5"], crab::BOOL_TYPE, 1);
-  z_var tmp6(vfac["tmp6"], crab::BOOL_TYPE, 1);
+  z_var tmp5(vfac["tmp5"], crab::BOOL_TYPE);
+  z_var tmp6(vfac["tmp6"], crab::BOOL_TYPE);
 
   entry >> bb1;
   bb1 >> bb1_t;

--- a/tests/domains/array_smashing.cc
+++ b/tests/domains/array_smashing.cc
@@ -9,7 +9,7 @@ using namespace crab::domain_impl;
 std::unique_ptr<z_cfg_t> prog1(variable_factory_t &vfac) {
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A0"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A0"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A0_prop"], crab::INT_TYPE, 32);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 32);
   z_var tmp5(vfac["tmp5"], crab::INT_TYPE, 32);
@@ -24,7 +24,7 @@ std::unique_ptr<z_cfg_t> prog1(variable_factory_t &vfac) {
   BB(cfg, bb2);
   BB(cfg, ret);
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
 
   entry >> bb1;
   bb1 >> bb1_t;
@@ -62,14 +62,14 @@ std::unique_ptr<z_cfg_t> prog2(variable_factory_t &vfac) {
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var n9(vfac["n9"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 32);
   z_var tmp4(vfac["tmp4"], crab::INT_TYPE, 32);
   z_var tmp5(vfac["tmp5"], crab::INT_TYPE, 32);
   z_var val(vfac["val"], crab::INT_TYPE, 32);
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
 
   entry >> bb1;
   bb1 >> bb1_t;
@@ -114,16 +114,16 @@ std::unique_ptr<z_cfg_t> prog3(variable_factory_t &vfac) {
 
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
-  z_var b(vfac["B"], crab::ARR_INT_TYPE, 32);
+  z_var b(vfac["B"], crab::ARR_INT_TYPE);
   z_var tmp1(vfac["tmp1"], crab::INT_TYPE, 32);
   z_var tmp2(vfac["tmp2"], crab::INT_TYPE, 32);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 32);
   z_var tmp4(vfac["tmp4"], crab::INT_TYPE, 32);
   z_var val(vfac["val"], crab::INT_TYPE, 32);
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
 
   entry.assign(a_p, 0);
   entry.array_init(a, 0, 9, a_p, elem_size);
@@ -155,9 +155,9 @@ std::unique_ptr<z_cfg_t> prog4(variable_factory_t &vfac) {
   BB(cfg, ret);
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
-  z_var b(vfac["B"], crab::ARR_INT_TYPE, 32);
+  z_var b(vfac["B"], crab::ARR_INT_TYPE);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 32);
   z_var tmp5(vfac["tmp5"], crab::INT_TYPE, 32);
   z_var tmp6(vfac["tmp6"], crab::INT_TYPE, 32);
@@ -171,7 +171,7 @@ std::unique_ptr<z_cfg_t> prog4(variable_factory_t &vfac) {
   bb2 >> bb1;
   bb1_f >> ret;
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
 
   entry.assign(a_p, 0);
   entry.array_init(a, 0, 9, a_p, elem_size);
@@ -203,13 +203,13 @@ std::unique_ptr<z_cfg_t> prog4b(variable_factory_t &vfac) {
   BB(cfg, ret);
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_BOOL_TYPE, 1);
-  z_var b(vfac["B"], crab::ARR_BOOL_TYPE, 1);
-  z_var tt(vfac["TRUE"], crab::BOOL_TYPE, 1);
-  z_var ff(vfac["FALSE"], crab::BOOL_TYPE, 1);
+  z_var a(vfac["A"], crab::ARR_BOOL_TYPE);
+  z_var b(vfac["B"], crab::ARR_BOOL_TYPE);
+  z_var tt(vfac["TRUE"], crab::BOOL_TYPE);
+  z_var ff(vfac["FALSE"], crab::BOOL_TYPE);
   z_var tmp3(vfac["tmp3"], crab::INT_TYPE, 32);
-  z_var tmp5(vfac["tmp5"], crab::BOOL_TYPE, 1);
-  z_var tmp6(vfac["tmp6"], crab::BOOL_TYPE, 1);
+  z_var tmp5(vfac["tmp5"], crab::BOOL_TYPE);
+  z_var tmp6(vfac["tmp6"], crab::BOOL_TYPE);
 
   entry >> bb1;
   bb1 >> bb1_t;
@@ -249,7 +249,7 @@ std::unique_ptr<z_cfg_t> prog5(variable_factory_t &vfac) {
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp1(vfac["tmp1"], crab::INT_TYPE, 32);
   z_var tmp2(vfac["tmp2"], crab::INT_TYPE, 32);
@@ -262,7 +262,7 @@ std::unique_ptr<z_cfg_t> prog5(variable_factory_t &vfac) {
   bb2 >> bb1;
   bb1_f >> ret;
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
   entry.assign(a_p, 0);
   entry.array_init(a, 0, n, a_p, elem_size);
 
@@ -289,7 +289,7 @@ std::unique_ptr<z_cfg_t> prog6(variable_factory_t &vfac) {
   BB(cfg, bb2);
   BB(cfg, ret);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp(vfac["tmp"], crab::INT_TYPE, 32);
   z_var offset(vfac["o"], crab::INT_TYPE, 32);
@@ -331,7 +331,7 @@ std::unique_ptr<z_cfg_t> prog7(variable_factory_t &vfac) {
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
   z_var i(vfac["i"], crab::INT_TYPE, 32);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp1(vfac["tmp1"], crab::INT_TYPE, 32);
   z_var tmp2(vfac["tmp2"], crab::INT_TYPE, 32);
@@ -346,7 +346,7 @@ std::unique_ptr<z_cfg_t> prog7(variable_factory_t &vfac) {
   bb2 >> bb1;
   bb1_f >> ret;
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
   // assume (forall i. a[i] =0);
   entry.assign(a_p, 0);
   entry.array_init(a, 0, n, a_p, elem_size);
@@ -385,7 +385,7 @@ std::unique_ptr<z_cfg_t> prog8(variable_factory_t &vfac) {
   z_var i(vfac["i"], crab::INT_TYPE, 32);
   z_var i1(vfac["i1"], crab::INT_TYPE, 32);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp1(vfac["tmp1"], crab::INT_TYPE, 32);
   z_var tmp2(vfac["tmp2"], crab::INT_TYPE, 32);
@@ -399,7 +399,7 @@ std::unique_ptr<z_cfg_t> prog8(variable_factory_t &vfac) {
   bb2 >> bb1;
   bb1_f >> ret;
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
   entry.assign(a_p, 0);
   entry.array_init(a, 0, 10, a_p, elem_size);
   entry.assume(n >= 1);
@@ -439,7 +439,7 @@ std::unique_ptr<z_cfg_t> prog9(variable_factory_t &vfac) {
   z_var i1(vfac["i1"], crab::INT_TYPE, 32);
   z_var i2(vfac["i2"], crab::INT_TYPE, 32);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
-  z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);
+  z_var a(vfac["A"], crab::ARR_INT_TYPE);
   z_var a_p(vfac["A_p"], crab::INT_TYPE, 32);
   z_var tmp1(vfac["tmp1"], crab::INT_TYPE, 32);
   z_var tmp2(vfac["tmp2"], crab::INT_TYPE, 32);
@@ -459,7 +459,7 @@ std::unique_ptr<z_cfg_t> prog9(variable_factory_t &vfac) {
   bb2_b >> bb1;
   bb1_f >> ret;
 
-  uint64_t elem_size = 1;
+  uint64_t elem_size = 4;
   entry.assign(a_p, 0);
   entry.array_init(a, 0, n, a_p, elem_size);
   entry.assume(n >= 1);

--- a/tests/domains/flat_bool_domain1-boxes.cc
+++ b/tests/domains/flat_bool_domain1-boxes.cc
@@ -35,12 +35,12 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
   z_var i(vfac["i"], crab::INT_TYPE, 32);
   z_var nd(vfac["nd"], crab::INT_TYPE, 32);
   z_var inc(vfac["inc"], crab::INT_TYPE, 32);
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var bfalse(vfac["bf"], crab::BOOL_TYPE, 1);
-  z_var btrue(vfac["bt"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var bfalse(vfac["bf"], crab::BOOL_TYPE);
+  z_var btrue(vfac["bt"], crab::BOOL_TYPE);
 
   // entry and exit block
   auto cfg = std::make_unique<z_cfg_t>("entry", "ret");

--- a/tests/domains/flat_bool_domain1.cc
+++ b/tests/domains/flat_bool_domain1.cc
@@ -35,12 +35,12 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
   z_var i(vfac["i"], crab::INT_TYPE, 32);
   z_var nd(vfac["nd"], crab::INT_TYPE, 32);
   z_var inc(vfac["inc"], crab::INT_TYPE, 32);
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var bfalse(vfac["bf"], crab::BOOL_TYPE, 1);
-  z_var btrue(vfac["bt"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var bfalse(vfac["bf"], crab::BOOL_TYPE);
+  z_var btrue(vfac["bt"], crab::BOOL_TYPE);
 
   // entry and exit block
   auto cfg = std::make_unique<z_cfg_t>("entry", "ret");

--- a/tests/domains/flat_bool_domain2.cc
+++ b/tests/domains/flat_bool_domain2.cc
@@ -26,7 +26,7 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
 
   // Defining program variables
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
 
   // entry and exit block

--- a/tests/domains/flat_bool_domain3.cc
+++ b/tests/domains/flat_bool_domain3.cc
@@ -29,7 +29,7 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
 
   // Defining program variables
   z_var i(vfac["i"], crab::INT_TYPE, 32);
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
   z_var n(vfac["n"], crab::INT_TYPE, 32);
 
   // entry and exit block

--- a/tests/domains/flat_bool_domain4.cc
+++ b/tests/domains/flat_bool_domain4.cc
@@ -25,7 +25,7 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
 
   // Defining program variables
   z_var i(vfac["i"], crab::INT_TYPE, 64);
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
   z_var n(vfac["n"], crab::INT_TYPE, 64);
   z_var n1(vfac["n1"], crab::INT_TYPE, 32);
 

--- a/tests/domains/flat_bool_domain5-boxes.cc
+++ b/tests/domains/flat_bool_domain5-boxes.cc
@@ -30,11 +30,11 @@ std::unique_ptr<z_cfg_t> prog2(variable_factory_t &vfac) {
    */
   
   // Defining program variables
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);  
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var b5(vfac["b5"], crab::BOOL_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 64);
 
   // entry and exit block
@@ -76,11 +76,11 @@ std::unique_ptr<z_cfg_t> prog3(variable_factory_t &vfac) {
    */
   
   // Defining program variables
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);  
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var b5(vfac["b5"], crab::BOOL_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 64);
 
   // entry and exit block

--- a/tests/domains/flat_bool_domain5.cc
+++ b/tests/domains/flat_bool_domain5.cc
@@ -27,11 +27,11 @@ std::unique_ptr<z_cfg_t> prog1(variable_factory_t &vfac) {
    */
   
   // Defining program variables
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);  
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var b5(vfac["b5"], crab::BOOL_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 64);
 
   // entry and exit block
@@ -76,11 +76,11 @@ std::unique_ptr<z_cfg_t> prog2(variable_factory_t &vfac) {
    */
   
   // Defining program variables
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);  
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var b5(vfac["b5"], crab::BOOL_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 64);
 
   // entry and exit block
@@ -122,11 +122,11 @@ std::unique_ptr<z_cfg_t> prog3(variable_factory_t &vfac) {
    */
   
   // Defining program variables
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-  z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);  
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var b4(vfac["b4"], crab::BOOL_TYPE);
+  z_var b5(vfac["b5"], crab::BOOL_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 64);
 
   // entry and exit block

--- a/tests/domains/flat_bool_domain6.cc
+++ b/tests/domains/flat_bool_domain6.cc
@@ -42,10 +42,10 @@ int main(int argc, char **argv) {
     bb1 >> bb4;
     bb2 >> bb3;
     bb4 >> bb3;
-    z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-    z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-    z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-    z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
+    z_var b1(vfac["b1"], crab::BOOL_TYPE);
+    z_var b2(vfac["b2"], crab::BOOL_TYPE);
+    z_var b3(vfac["b3"], crab::BOOL_TYPE);
+    z_var b4(vfac["b4"], crab::BOOL_TYPE);
     // adding statements
     bb1.havoc(b1);
     bb1.havoc(b2);

--- a/tests/domains/flat_bool_domain7.cc
+++ b/tests/domains/flat_bool_domain7.cc
@@ -32,12 +32,12 @@ int main(int argc, char **argv) {
     z_basic_block_t &exit = cfg.insert("exit");
     // adding control flow
     entry >> exit;
-    z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-    z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-    z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-    z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-    z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);
-    z_var b6(vfac["b6"], crab::BOOL_TYPE, 1);
+    z_var b1(vfac["b1"], crab::BOOL_TYPE);
+    z_var b2(vfac["b2"], crab::BOOL_TYPE);
+    z_var b3(vfac["b3"], crab::BOOL_TYPE);
+    z_var b4(vfac["b4"], crab::BOOL_TYPE);
+    z_var b5(vfac["b5"], crab::BOOL_TYPE);
+    z_var b6(vfac["b6"], crab::BOOL_TYPE);
     z_var x(vfac["x"], crab::INT_TYPE, 32);
     z_var y(vfac["y"], crab::INT_TYPE, 32);
 

--- a/tests/domains/flat_bool_domain8.cc
+++ b/tests/domains/flat_bool_domain8.cc
@@ -40,11 +40,11 @@ exit:
   bb1 >> exit;
   bb2 >> exit;
   
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-  z_var bTrue(vfac["bTrue"], crab::BOOL_TYPE, 1);
-  z_var bFalse(vfac["bFalse"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
+  z_var bTrue(vfac["bTrue"], crab::BOOL_TYPE);
+  z_var bFalse(vfac["bFalse"], crab::BOOL_TYPE);
   z_var x(vfac["x"], crab::INT_TYPE, 32);
   z_var y(vfac["y"], crab::INT_TYPE, 32);
 

--- a/tests/domains/flat_bool_domain9.cc
+++ b/tests/domains/flat_bool_domain9.cc
@@ -40,9 +40,9 @@ std::unique_ptr<z_cfg_t> prog(variable_factory_t &vfac) {
   */ 
   // Defining program variables
   z_var x(vfac["x"], crab::INT_TYPE, 32);
-  z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-  z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-  z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
+  z_var b1(vfac["b1"], crab::BOOL_TYPE);
+  z_var b2(vfac["b2"], crab::BOOL_TYPE);
+  z_var b3(vfac["b3"], crab::BOOL_TYPE);
   z_var x1(vfac["x1"], crab::INT_TYPE, 32);
   z_var x2(vfac["x2"], crab::INT_TYPE, 32);
   z_var x3(vfac["x3"], crab::INT_TYPE, 32);

--- a/tests/domains/region/region-3.cc
+++ b/tests/domains/region/region-3.cc
@@ -39,21 +39,21 @@ int main() {
   z_var i0(vfac["i0"], crab::INT_TYPE, 32);
   z_var x1(vfac["x1"], crab::INT_TYPE, 32);
   z_var x2(vfac["x2"], crab::INT_TYPE, 32);    
-  z_var ref0(vfac["ref0"], crab::REF_TYPE, 32);
-  z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-  z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-  z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
-  z_var ref4(vfac["ref4"], crab::REF_TYPE, 32);
-  z_var ref5(vfac["ref5"], crab::REF_TYPE, 32);
-  z_var ref6(vfac["ref6"], crab::REF_TYPE, 32);
-  z_var ref7(vfac["ref7"], crab::REF_TYPE, 32);
-  z_var ref8(vfac["ref8"], crab::REF_TYPE, 32);
-  z_var ref9(vfac["ref9"], crab::REF_TYPE, 32);
+  z_var ref0(vfac["ref0"], crab::REF_TYPE);
+  z_var ref1(vfac["ref1"], crab::REF_TYPE);
+  z_var ref2(vfac["ref2"], crab::REF_TYPE);
+  z_var ref3(vfac["ref3"], crab::REF_TYPE);
+  z_var ref4(vfac["ref4"], crab::REF_TYPE);
+  z_var ref5(vfac["ref5"], crab::REF_TYPE);
+  z_var ref6(vfac["ref6"], crab::REF_TYPE);
+  z_var ref7(vfac["ref7"], crab::REF_TYPE);
+  z_var ref8(vfac["ref8"], crab::REF_TYPE);
+  z_var ref9(vfac["ref9"], crab::REF_TYPE);
   
   // Define memory regions
   z_var mem_field_f(vfac["region_field_f"], crab::REG_INT_TYPE, 32);
   z_var mem_field_s(vfac["region_field_s"], crab::REG_INT_TYPE, 32);  
-  z_var mem_field_next(vfac["region_field_next"], crab::REG_REF_TYPE, 32);
+  z_var mem_field_next(vfac["region_field_next"], crab::REG_REF_TYPE);
 
   // Create allocation sites
   crab::tag_manager as_man;

--- a/tests/domains/region/region-4.cc
+++ b/tests/domains/region/region-4.cc
@@ -46,23 +46,23 @@ int main() {
   z_var i0(vfac["i0"], crab::INT_TYPE, 32);
   z_var x1(vfac["x1"], crab::INT_TYPE, 32);
   z_var x2(vfac["x2"], crab::INT_TYPE, 32);    
-  z_var ref0(vfac["ref0"], crab::REF_TYPE, 32);
-  z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-  z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-  z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
-  z_var ref4(vfac["ref4"], crab::REF_TYPE, 32);
-  z_var ref5(vfac["ref5"], crab::REF_TYPE, 32);
-  z_var ref6(vfac["ref6"], crab::REF_TYPE, 32);
-  z_var ref7(vfac["ref7"], crab::REF_TYPE, 32);
-  z_var ref8(vfac["ref8"], crab::REF_TYPE, 32);
-  z_var ref9(vfac["ref9"], crab::REF_TYPE, 32);
-  z_var ref10(vfac["ref10"], crab::REF_TYPE, 32);  
+  z_var ref0(vfac["ref0"], crab::REF_TYPE);
+  z_var ref1(vfac["ref1"], crab::REF_TYPE);
+  z_var ref2(vfac["ref2"], crab::REF_TYPE);
+  z_var ref3(vfac["ref3"], crab::REF_TYPE);
+  z_var ref4(vfac["ref4"], crab::REF_TYPE);
+  z_var ref5(vfac["ref5"], crab::REF_TYPE);
+  z_var ref6(vfac["ref6"], crab::REF_TYPE);
+  z_var ref7(vfac["ref7"], crab::REF_TYPE);
+  z_var ref8(vfac["ref8"], crab::REF_TYPE);
+  z_var ref9(vfac["ref9"], crab::REF_TYPE);
+  z_var ref10(vfac["ref10"], crab::REF_TYPE);  
   
   // Define memory regions
   z_var mem_field_f(vfac["region_field_f"], crab::REG_INT_TYPE, 32);
-  z_var mem_field_s(vfac["region_field_s"], crab::REG_REF_TYPE, 32);
+  z_var mem_field_s(vfac["region_field_s"], crab::REG_REF_TYPE);
   z_var mem_field_deref_s(vfac["region_field_deref_s"], crab::REG_INT_TYPE, 32);    
-  z_var mem_field_next(vfac["region_field_next"], crab::REG_REF_TYPE, 32);
+  z_var mem_field_next(vfac["region_field_next"], crab::REG_REF_TYPE);
 
   // Create allocation sites
   crab::tag_manager as_man;

--- a/tests/domains/region/region-7.cc
+++ b/tests/domains/region/region-7.cc
@@ -36,10 +36,10 @@ std::unique_ptr<z_cfg_t> cfg1(variable_factory_t &vfac) {
   z_var res(vfac["res"], crab::REF_TYPE);
   z_var orphan_ptr(vfac["orphan_ptr"], crab::REF_TYPE);  
   z_var x(vfac["x"], crab::INT_TYPE, 32);    
-  z_var m1(vfac["rgn_0"], crab::REG_REF_TYPE, 32);
-  z_var m2(vfac["rgn_1"], crab::REG_REF_TYPE, 32);
-  z_var m3(vfac["rgn_2"], crab::REG_REF_TYPE, 32);
-  z_var m4(vfac["rgn_3"], crab::REG_REF_TYPE, 32);  
+  z_var m1(vfac["rgn_0"], crab::REG_REF_TYPE);
+  z_var m2(vfac["rgn_1"], crab::REG_REF_TYPE);
+  z_var m3(vfac["rgn_2"], crab::REG_REF_TYPE);
+  z_var m4(vfac["rgn_3"], crab::REG_REF_TYPE);  
   // === Create allocation sites
   crab::tag_manager as_man;  
   // Create empty CFG
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
    */
   
   z_var f_ptr(vfac["fun_ptr"], crab::REF_TYPE);
-  z_var m(vfac["rgn_3"], crab::REG_REF_TYPE, 32);  // region of f_ptr
+  z_var m(vfac["rgn_3"], crab::REG_REF_TYPE);  // region of f_ptr
   z_var deref_f_ptr(vfac["*fun_ptr"], crab::REF_TYPE);
   z_var orphan_ptr(vfac["orphan_ptr"], crab::REF_TYPE);    
   z_rgn_sdbm_t exit_inv = a["ret"];

--- a/tests/domains/unittests-herbrand.cc
+++ b/tests/domains/unittests-herbrand.cc
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     crab::outs() << "=== Arrays ==== \n";
     {
       z_herbrand_domain_t dom;
-      z_var a(vfac["A"], crab::ARR_INT_TYPE, 32);    
+      z_var a(vfac["A"], crab::ARR_INT_TYPE);    
       z_var x(vfac["x"], crab::INT_TYPE, 32);
       z_var y(vfac["y"], crab::INT_TYPE, 32);
       z_var w(vfac["w"], crab::INT_TYPE, 32);
@@ -150,13 +150,13 @@ int main(int argc, char **argv) {
   
     crab::outs() << "==== Boolean operations ====\n";
     {
-      z_var b1(vfac["b1"], crab::BOOL_TYPE, 1);
-      z_var b2(vfac["b2"], crab::BOOL_TYPE, 1);
-      z_var b3(vfac["b3"], crab::BOOL_TYPE, 1);
-      z_var b4(vfac["b4"], crab::BOOL_TYPE, 1);
-      z_var b5(vfac["b5"], crab::BOOL_TYPE, 1);
-      z_var b6(vfac["b6"], crab::BOOL_TYPE, 1);
-      z_var b7(vfac["b7"], crab::BOOL_TYPE, 1);            
+      z_var b1(vfac["b1"], crab::BOOL_TYPE);
+      z_var b2(vfac["b2"], crab::BOOL_TYPE);
+      z_var b3(vfac["b3"], crab::BOOL_TYPE);
+      z_var b4(vfac["b4"], crab::BOOL_TYPE);
+      z_var b5(vfac["b5"], crab::BOOL_TYPE);
+      z_var b6(vfac["b6"], crab::BOOL_TYPE);
+      z_var b7(vfac["b7"], crab::BOOL_TYPE);            
 
       z_herbrand_domain_t dom;
       dom.assign_bool_var(b4, b5, false);

--- a/tests/domains/unittests-lincst-export.cc
+++ b/tests/domains/unittests-lincst-export.cc
@@ -92,8 +92,8 @@ BOOST_AUTO_TEST_CASE(bottom_exports_a_contradiction) {
 
 BOOST_AUTO_TEST_CASE(known_booleans_export_as_zero_one_equalities) {
   variable_factory_t vfac;
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
-  z_var c(vfac["c"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
+  z_var c(vfac["c"], crab::BOOL_TYPE);
 
   flat_bool_domain_t dom;
   dom.assume_bool(b, false /*not negated*/); // b is true
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(numerical_only_survives_a_top_boolean_component) {
 
 BOOST_AUTO_TEST_CASE(boolean_only_is_exported) {
   variable_factory_t vfac;
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
 
   product_domain_t dom;
   dom.assume_bool(b, false /*not negated*/);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(boolean_only_is_exported) {
 // disjunct holding both facts.
 BOOST_AUTO_TEST_CASE(components_are_conjoined_not_disjoined) {
   variable_factory_t vfac;
-  z_var b(vfac["b"], crab::BOOL_TYPE, 1);
+  z_var b(vfac["b"], crab::BOOL_TYPE);
   z_var y(vfac["y"], crab::INT_TYPE, 32);
 
   product_domain_t dom;

--- a/tests/domains/unittests-regions.cc
+++ b/tests/domains/unittests-regions.cc
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
   { // join
     z_var x(vfac["x"], crab::INT_TYPE, 32);
     z_var y(vfac["y"], crab::INT_TYPE, 32);
-    z_var ref(vfac["ref"], crab::REF_TYPE, 32);    
+    z_var ref(vfac["ref"], crab::REF_TYPE);    
     z_var rgn1(vfac["region_0"], crab::REG_INT_TYPE, 32);
     z_var_or_cst_t n34_32(z_number(34), crab::variable_type(crab::INT_TYPE, 32));
     
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
   { // join
     z_var x(vfac["x"], crab::INT_TYPE, 32);
     z_var y(vfac["y"], crab::INT_TYPE, 32);
-    z_var ref(vfac["ref"], crab::REF_TYPE, 32);    
+    z_var ref(vfac["ref"], crab::REF_TYPE);    
     z_var rgn1(vfac["region_0"], crab::REG_INT_TYPE, 32);
 
     z_var_or_cst_t n34_32(z_number(34), crab::variable_type(crab::INT_TYPE, 32));
@@ -78,13 +78,13 @@ int main(int argc, char **argv) {
       z_basic_block_t &entry = cfg.insert("entry");
       z_basic_block_t &exit = cfg.insert("exit");
       entry >> exit;
-      z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-      z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-      z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
+      z_var ref1(vfac["ref1"], crab::REF_TYPE);
+      z_var ref2(vfac["ref2"], crab::REF_TYPE);
+      z_var ref3(vfac["ref3"], crab::REF_TYPE);
       z_var rgn1(vfac["rgn1"], crab::REG_INT_TYPE, 32);
       z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
       z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
-      z_var cond(vfac["cond"], crab::BOOL_TYPE, 1);    
+      z_var cond(vfac["cond"], crab::BOOL_TYPE);    
       z_rgn_int_t init;      
       entry.region_init(rgn1);
       entry.region_init(rgn2);
@@ -103,13 +103,13 @@ int main(int argc, char **argv) {
       z_basic_block_t &entry = cfg.insert("entry");
       z_basic_block_t &exit = cfg.insert("exit");
       entry >> exit;
-      z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-      z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-      z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
+      z_var ref1(vfac["ref1"], crab::REF_TYPE);
+      z_var ref2(vfac["ref2"], crab::REF_TYPE);
+      z_var ref3(vfac["ref3"], crab::REF_TYPE);
       z_var rgn1(vfac["rgn1"], crab::REG_INT_TYPE, 32);
       z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
       z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
-      z_var cond(vfac["cond"], crab::BOOL_TYPE, 1);    
+      z_var cond(vfac["cond"], crab::BOOL_TYPE);    
       z_rgn_bool_int_t init;
       entry.region_init(rgn1);
       entry.region_init(rgn2);
@@ -128,13 +128,13 @@ int main(int argc, char **argv) {
       z_basic_block_t &entry = cfg.insert("entry");
       z_basic_block_t &exit = cfg.insert("exit");
       entry >> exit;
-      z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-      z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-      z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
+      z_var ref1(vfac["ref1"], crab::REF_TYPE);
+      z_var ref2(vfac["ref2"], crab::REF_TYPE);
+      z_var ref3(vfac["ref3"], crab::REF_TYPE);
       z_var rgn1(vfac["rgn1"], crab::REG_INT_TYPE, 32);
       z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
       z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
-      z_var cond(vfac["cond"], crab::BOOL_TYPE, 1);    
+      z_var cond(vfac["cond"], crab::BOOL_TYPE);    
       z_rgn_int_t init;      
       entry.region_init(rgn1);
       entry.region_init(rgn2);
@@ -152,13 +152,13 @@ int main(int argc, char **argv) {
       z_basic_block_t &entry = cfg.insert("entry");
       z_basic_block_t &exit = cfg.insert("exit");
       entry >> exit;
-      z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-      z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-      z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
+      z_var ref1(vfac["ref1"], crab::REF_TYPE);
+      z_var ref2(vfac["ref2"], crab::REF_TYPE);
+      z_var ref3(vfac["ref3"], crab::REF_TYPE);
       z_var rgn1(vfac["rgn1"], crab::REG_INT_TYPE, 32);
       z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
       z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
-      z_var cond(vfac["cond"], crab::BOOL_TYPE, 1);    
+      z_var cond(vfac["cond"], crab::BOOL_TYPE);    
       z_rgn_bool_int_t init;
       entry.region_init(rgn1);
       entry.region_init(rgn2);
@@ -176,13 +176,13 @@ int main(int argc, char **argv) {
       z_basic_block_t &entry = cfg.insert("entry");
       z_basic_block_t &exit = cfg.insert("exit");
       entry >> exit;
-      z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-      z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
-      z_var ref3(vfac["ref3"], crab::REF_TYPE, 32);
+      z_var ref1(vfac["ref1"], crab::REF_TYPE);
+      z_var ref2(vfac["ref2"], crab::REF_TYPE);
+      z_var ref3(vfac["ref3"], crab::REF_TYPE);
       z_var rgn1(vfac["rgn1"], crab::REG_INT_TYPE, 32);
       z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
       z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
-      z_var cond(vfac["cond"], crab::BOOL_TYPE, 1);    
+      z_var cond(vfac["cond"], crab::BOOL_TYPE);    
       z_rgn_bool_int_t init;
       entry.assume_ref(z_ref_cst_t::mk_gt_null(ref3));
       entry.bool_assign(cond, z_lin_cst_t::get_false());
@@ -217,8 +217,8 @@ int main(int argc, char **argv) {
 	z_var rgn2(vfac["rgn2"], crab::REG_INT_TYPE, 32);
 	z_var rgn3(vfac["rgn3"], crab::REG_INT_TYPE, 32);
 	z_var rgn4(vfac["rgn4"], crab::REG_INT_TYPE, 32);	
-	z_var ref1(vfac["ref1"], crab::REF_TYPE, 32);
-	z_var ref2(vfac["ref2"], crab::REF_TYPE, 32);
+	z_var ref1(vfac["ref1"], crab::REF_TYPE);
+	z_var ref2(vfac["ref2"], crab::REF_TYPE);
 	
 	z_rgn_bool_int_t dom;
 	dom.region_init(rgn1);

--- a/tests/expected_results.out
+++ b/tests/expected_results.out
@@ -899,9 +899,9 @@ user-defined assertion checker
 0  Number of total unreachable checks
 
 entry:
-  region_init(region_0:region(int));
-  i := make_ref(region_0:region(int),4,as_0);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
+  region_init(region_0:region(int32));
+  i := make_ref(region_0:region(int32),4,as_0);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
@@ -910,23 +910,23 @@ bb1_t:
 bb2:
   havoc(nd);
   inc = ite(-nd <= -1,1,1);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+inc;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   goto bb3,bb4;
 bb3:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -1);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
   goto bb1;
 bb4:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 0);
   goto bb1;
 bb1_f:
   goto ret;
 ret:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assert(*i = 0);
 
 
@@ -1026,7 +1026,7 @@ CFG
 x0:
   k = 2147483648;
   o = 4;
-  p := make_ref(region_0:region(int),400,as_0);
+  p := make_ref(region_0:region(int32),400,as_0);
   goto x1;
 x1:
   goto x2;
@@ -1044,7 +1044,7 @@ bb1_t:
   goto bb2;
 bb2:
   havoc(nd);
-  (region_0:region(int),q:ref) := gep_ref(region_0:region(int),p:ref + o);
+  (region_0:region(int32),q:ref) := gep_ref(region_0:region(int32),p:ref + o);
   k = 5;
   inc = ite(-nd <= -1,1,2);
   i = i+inc;
@@ -1087,7 +1087,7 @@ Cloned CFG
 x0:
   k = 2147483648;
   o = 4;
-  p := make_ref(region_0:region(int),400,as_0);
+  p := make_ref(region_0:region(int32),400,as_0);
   goto x1;
 x1:
   goto x2;
@@ -1105,7 +1105,7 @@ bb1_t:
   goto bb2;
 bb2:
   havoc(nd);
-  (region_0:region(int),q:ref) := gep_ref(region_0:region(int),p:ref + o);
+  (region_0:region(int32),q:ref) := gep_ref(region_0:region(int32),p:ref + o);
   k = 5;
   inc = ite(-nd <= -1,1,2);
   i = i+inc;
@@ -1121,7 +1121,7 @@ k:int32 declare main()
 x0:
   k = 2147483648;
   o = 4;
-  p := make_ref(region_0:region(int),400,as_1);
+  p := make_ref(region_0:region(int32),400,as_1);
   goto x1;
 x1:
   goto x2;
@@ -1139,7 +1139,7 @@ bb1_t:
   goto bb2;
 bb2:
   havoc(nd);
-  (region_0:region(int),q:ref) := gep_ref(region_0:region(int),p:ref + o);
+  (region_0:region(int32),q:ref) := gep_ref(region_0:region(int32),p:ref + o);
   k = 5;
   inc = ite(-nd <= -1,1,2);
   i = i+inc;
@@ -1148,14 +1148,14 @@ bb1_f:
   assume(-i <= -100);
   goto ret;
 ret:
-  k:int32 := load_from_ref(region_0:region(int),q:ref);
+  k:int32 := load_from_ref(region_0:region(int32),q:ref);
 
 
 After Dead Code Elimination
 k:int32 declare main()
 x0:
   o = 4;
-  p := make_ref(region_0:region(int),400,as_1);
+  p := make_ref(region_0:region(int32),400,as_1);
   goto x1;
 x1:
   goto x2;
@@ -1173,7 +1173,7 @@ bb1_t:
   goto bb2;
 bb2:
   havoc(nd);
-  (region_0:region(int),q:ref) := gep_ref(region_0:region(int),p:ref + o);
+  (region_0:region(int32),q:ref) := gep_ref(region_0:region(int32),p:ref + o);
   inc = ite(-nd <= -1,1,2);
   i = i+inc;
   goto bb1;
@@ -1181,7 +1181,7 @@ bb1_f:
   assume(-i <= -100);
   goto ret;
 ret:
-  k:int32 := load_from_ref(region_0:region(int),q:ref);
+  k:int32 := load_from_ref(region_0:region(int32),q:ref);
 
 
 Cloned CFG
@@ -1189,7 +1189,7 @@ k:int32 declare main()
 x0:
   k = 2147483648;
   o = 4;
-  p := make_ref(region_0:region(int),400,as_1);
+  p := make_ref(region_0:region(int32),400,as_1);
   goto x1;
 x1:
   goto x2;
@@ -1207,7 +1207,7 @@ bb1_t:
   goto bb2;
 bb2:
   havoc(nd);
-  (region_0:region(int),q:ref) := gep_ref(region_0:region(int),p:ref + o);
+  (region_0:region(int32),q:ref) := gep_ref(region_0:region(int32),p:ref + o);
   k = 5;
   inc = ite(-nd <= -1,1,2);
   i = i+inc;
@@ -1216,7 +1216,7 @@ bb1_f:
   assume(-i <= -100);
   goto ret;
 ret:
-  k:int32 := load_from_ref(region_0:region(int),q:ref);
+  k:int32 := load_from_ref(region_0:region(int32),q:ref);
 
 
 === End ./test-bin/dce ===
@@ -1778,8 +1778,8 @@ entry:
   i = 0;
   x = 1;
   y = 0;
-  p := make_ref(region_0:region(int),8,as_0);
-  (region_0:region(int),l:ref) := gep_ref(region_0:region(int),p:ref);
+  p := make_ref(region_0:region(int32),8,as_0);
+  (region_0:region(int32),l:ref) := gep_ref(region_0:region(int32),p:ref);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
@@ -1789,11 +1789,11 @@ bb1_t:
 bb2:
   x = x+y;
   y = y+1;
-  store_to_ref(region_0:region(int),p:ref,i:int32);
-  q := make_ref(region_0:region(int),8,as_1);
-  (region_0:region(int),p_next:ref) := gep_ref(region_0:region(int),p:ref + 4);
-  store_to_ref(region_0:region(int),p_next:ref,q:ref);
-  (region_0:region(int),p:ref) := gep_ref(region_0:region(int),p_next:ref);
+  store_to_ref(region_0:region(int32),p:ref,i:int32);
+  q := make_ref(region_0:region(int32),8,as_1);
+  (region_0:region(int32),p_next:ref) := gep_ref(region_0:region(int32),p:ref + 4);
+  store_to_ref(region_0:region(int32),p_next:ref,q:ref);
+  (region_0:region(int32),p:ref) := gep_ref(region_0:region(int32),p_next:ref);
   i = i+1;
   goto bb1;
 bb1_f:
@@ -1812,8 +1812,8 @@ entry:
   i = 0;
   x = 1;
   y = 0;
-  p := make_ref(region_0:region(int),8,as_0);
-  (region_0:region(int),l:ref) := gep_ref(region_0:region(int),p:ref);
+  p := make_ref(region_0:region(int32),8,as_0);
+  (region_0:region(int32),l:ref) := gep_ref(region_0:region(int32),p:ref);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
@@ -1823,11 +1823,11 @@ bb1_t:
 bb2:
   x = x+y;
   y = y+1;
-  store_to_ref(region_0:region(int),p:ref,i:int32);
-  q := make_ref(region_0:region(int),8,as_1);
-  (region_0:region(int),p_next:ref) := gep_ref(region_0:region(int),p:ref + 4);
-  store_to_ref(region_0:region(int),p_next:ref,q:ref);
-  (region_0:region(int),p:ref) := gep_ref(region_0:region(int),p_next:ref);
+  store_to_ref(region_0:region(int32),p:ref,i:int32);
+  q := make_ref(region_0:region(int32),8,as_1);
+  (region_0:region(int32),p_next:ref) := gep_ref(region_0:region(int32),p:ref + 4);
+  store_to_ref(region_0:region(int32),p_next:ref,q:ref);
+  (region_0:region(int32),p:ref) := gep_ref(region_0:region(int32),p_next:ref);
   i = i+1;
   goto bb1;
 bb1_f:
@@ -2001,41 +2001,41 @@ user-defined assertion checker
 === End ./test-bin/powerset ===
 === Begin ./test-bin/region-1 ===
 entry:
-  region_init(region_0:region(int));
-  region_init(region_1:region(int));
-  region_init(region_2:region(int));
-  i := make_ref(region_0:region(int),4,as_0);
-  x := make_ref(region_1:region(int),4,as_1);
-  y := make_ref(region_2:region(int),4,as_2);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
-  store_to_ref(region_1:region(int),x:ref,1:int32);
-  store_to_ref(region_2:region(int),y:ref,0:int32);
+  region_init(region_0:region(int32));
+  region_init(region_1:region(int32));
+  region_init(region_2:region(int32));
+  i := make_ref(region_0:region(int32),4,as_0);
+  x := make_ref(region_1:region(int32),4,as_1);
+  y := make_ref(region_2:region(int32),4,as_2);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
+  store_to_ref(region_1:region(int32),x:ref,1:int32);
+  store_to_ref(region_2:region(int32),y:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
 bb1_t:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 99);
   goto bb2;
 bb2:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *x = *x+*y;
-  store_to_ref(region_1:region(int),x:ref,*x:int32);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  store_to_ref(region_1:region(int32),x:ref,*x:int32);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *y = *y+1;
-  store_to_ref(region_2:region(int),y:ref,*y:int32);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  store_to_ref(region_2:region(int32),y:ref,*y:int32);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+1;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   goto bb1;
 bb1_f:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -100);
   goto bb3;
 bb3:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   goto ret;
 ret:
   assert(-*x+*y <= 0);
@@ -2052,46 +2052,46 @@ user-defined assertion checker
 === End ./test-bin/region-1 ===
 === Begin ./test-bin/region-2 ===
 entry:
-  region_init(region_0:region(int));
-  region_init(region_1:region(int));
-  region_init(region_2:region(int));
-  i := make_ref(region_0:region(int),4,as_0);
-  x := make_ref(region_1:region(int),4,as_1);
-  y := make_ref(region_2:region(int),4,as_2);
+  region_init(region_0:region(int32));
+  region_init(region_1:region(int32));
+  region_init(region_2:region(int32));
+  i := make_ref(region_0:region(int32),4,as_0);
+  x := make_ref(region_1:region(int32),4,as_1);
+  y := make_ref(region_2:region(int32),4,as_2);
   assume(i > NULL_REF);
   assume(x > NULL_REF);
   assume(y > NULL_REF);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
-  store_to_ref(region_1:region(int),x:ref,1:int32);
-  store_to_ref(region_2:region(int),y:ref,0:int32);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
+  store_to_ref(region_1:region(int32),x:ref,1:int32);
+  store_to_ref(region_2:region(int32),y:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
 bb1_t:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 99);
   goto bb2;
 bb2:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *x = *x+*y;
-  store_to_ref(region_1:region(int),x:ref,*x:int32);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  store_to_ref(region_1:region(int32),x:ref,*x:int32);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *y = *y+1;
-  store_to_ref(region_2:region(int),y:ref,*y:int32);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  store_to_ref(region_2:region(int32),y:ref,*y:int32);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+1;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   goto bb1;
 bb1_f:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -100);
   goto ret;
 ret:
   assert(x != NULL_REF);
   assert(y != NULL_REF);
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   assert(-*x+*y <= 0);
 
 
@@ -2107,8 +2107,8 @@ user-defined assertion checker
 === Begin ./test-bin/region-3 ===
 entry:
   region_init(region_field_next:region(ref));
-  region_init(region_field_s:region(int));
-  region_init(region_field_f:region(int));
+  region_init(region_field_s:region(int32));
+  region_init(region_field_f:region(int32));
   i0 = 0;
   assume(ref0 == NULL_REF);
   goto bb2_loop;
@@ -2118,20 +2118,20 @@ bb3:
   assume(i0 <= 9999);
   goto bb5;
 bb5:
-  ref2 := make_ref(region_field_f:region(int),16,as_0);
+  ref2 := make_ref(region_field_f:region(int32),16,as_0);
   assume(ref2 > NULL_REF);
-  (region_field_f:region(int),ref3:ref) := gep_ref(region_field_f:region(int),ref2:ref);
-  store_to_ref(region_field_f:region(int),ref3:ref,i0:int32);
-  (region_field_s:region(int),ref5:ref) := gep_ref(region_field_f:region(int),ref2:ref + 4);
-  store_to_ref(region_field_s:region(int),ref5:ref,30000:int32);
-  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int),ref2:ref + 8);
+  (region_field_f:region(int32),ref3:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
+  store_to_ref(region_field_f:region(int32),ref3:ref,i0:int32);
+  (region_field_s:region(int32),ref5:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 4);
+  store_to_ref(region_field_s:region(int32),ref5:ref,30000:int32);
+  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 8);
   store_to_ref(region_field_next:region(ref),ref4:ref,ref0:ref);
   i0 = i0+1;
-  (region_field_f:region(int),ref0:ref) := gep_ref(region_field_f:region(int),ref2:ref);
+  (region_field_f:region(int32),ref0:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
   goto bb2_loop;
 bb4:
   assume(-i0 <= -10000);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref0:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref0:ref);
   goto bb6_loop;
 bb6_loop:
   goto bb7,bb8;
@@ -2144,15 +2144,15 @@ bb8:
   assume(ref1 != NULL_REF);
   goto bb9;
 bb9:
-  (region_field_f:region(int),ref6:ref) := gep_ref(region_field_f:region(int),ref1:ref);
-  x1:int32 := load_from_ref(region_field_f:region(int),ref6:ref);
+  (region_field_f:region(int32),ref6:ref) := gep_ref(region_field_f:region(int32),ref1:ref);
+  x1:int32 := load_from_ref(region_field_f:region(int32),ref6:ref);
   assert(x1 <= 9999);
-  (region_field_s:region(int),ref7:ref) := gep_ref(region_field_f:region(int),ref1:ref + 4);
-  x2:int32 := load_from_ref(region_field_s:region(int),ref7:ref);
+  (region_field_s:region(int32),ref7:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 4);
+  x2:int32 := load_from_ref(region_field_s:region(int32),ref7:ref);
   assert(x2 <= 30000);
-  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int),ref1:ref + 8);
+  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 8);
   ref9:ref := load_from_ref(region_field_next:region(ref),ref8:ref);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref9:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref9:ref);
   goto bb6_loop;
 
 Invariants using Region
@@ -2168,8 +2168,8 @@ user-defined assertion checker
 entry:
   region_init(region_field_next:region(ref));
   region_init(region_field_s:region(ref));
-  region_init(region_field_deref_s:region(int));
-  region_init(region_field_f:region(int));
+  region_init(region_field_deref_s:region(int32));
+  region_init(region_field_f:region(int32));
   i0 = 0;
   assume(ref0 == NULL_REF);
   goto bb2_loop;
@@ -2179,22 +2179,22 @@ bb3:
   assume(i0 <= 9999);
   goto bb5;
 bb5:
-  ref2 := make_ref(region_field_f:region(int),16,as_0);
+  ref2 := make_ref(region_field_f:region(int32),16,as_0);
   assume(ref2 > NULL_REF);
-  (region_field_f:region(int),ref3:ref) := gep_ref(region_field_f:region(int),ref2:ref);
-  store_to_ref(region_field_f:region(int),ref3:ref,i0:int32);
-  (region_field_s:region(ref),ref5:ref) := gep_ref(region_field_f:region(int),ref2:ref + 4);
-  ref10 := make_ref(region_field_deref_s:region(int),4,as_1);
+  (region_field_f:region(int32),ref3:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
+  store_to_ref(region_field_f:region(int32),ref3:ref,i0:int32);
+  (region_field_s:region(ref),ref5:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 4);
+  ref10 := make_ref(region_field_deref_s:region(int32),4,as_1);
   assume(ref10 > NULL_REF);
   store_to_ref(region_field_s:region(ref),ref5:ref,ref10:ref);
-  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int),ref2:ref + 8);
+  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 8);
   store_to_ref(region_field_next:region(ref),ref4:ref,ref0:ref);
   i0 = i0+1;
-  (region_field_f:region(int),ref0:ref) := gep_ref(region_field_f:region(int),ref2:ref);
+  (region_field_f:region(int32),ref0:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
   goto bb2_loop;
 bb4:
   assume(-i0 <= -10000);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref0:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref0:ref);
   goto bb6_loop;
 bb6_loop:
   goto bb7,bb8;
@@ -2207,15 +2207,15 @@ bb8:
   assume(ref1 != NULL_REF);
   goto bb9;
 bb9:
-  (region_field_s:region(ref),ref7:ref) := gep_ref(region_field_f:region(int),ref1:ref + 4);
+  (region_field_s:region(ref),ref7:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 4);
   ref6:ref := load_from_ref(region_field_s:region(ref),ref7:ref);
-  b2 = crab_intrinsic(is_unfreed_or_null,region_field_deref_s:region(int),ref6:ref);
+  b2 = crab_intrinsic(is_unfreed_or_null,region_field_deref_s:region(int32),ref6:ref);
   goto bb9_assert;
 bb9_assert:
   assert(b2);
-  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int),ref1:ref + 8);
+  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 8);
   ref9:ref := load_from_ref(region_field_next:region(ref),ref8:ref);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref9:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref9:ref);
   goto bb6_loop;
 
 Invariants using Region
@@ -2229,8 +2229,8 @@ user-defined assertion checker
 entry:
   region_init(region_field_next:region(ref));
   region_init(region_field_s:region(ref));
-  region_init(region_field_deref_s:region(int));
-  region_init(region_field_f:region(int));
+  region_init(region_field_deref_s:region(int32));
+  region_init(region_field_f:region(int32));
   i0 = 0;
   assume(ref0 == NULL_REF);
   goto bb2_loop;
@@ -2240,22 +2240,22 @@ bb3:
   assume(i0 <= 9999);
   goto bb5;
 bb5:
-  ref2 := make_ref(region_field_f:region(int),16,as_0);
+  ref2 := make_ref(region_field_f:region(int32),16,as_0);
   assume(ref2 > NULL_REF);
-  (region_field_f:region(int),ref3:ref) := gep_ref(region_field_f:region(int),ref2:ref);
-  store_to_ref(region_field_f:region(int),ref3:ref,i0:int32);
-  (region_field_s:region(ref),ref5:ref) := gep_ref(region_field_f:region(int),ref2:ref + 4);
-  ref10 := make_ref(region_field_deref_s:region(int),4,as_1);
+  (region_field_f:region(int32),ref3:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
+  store_to_ref(region_field_f:region(int32),ref3:ref,i0:int32);
+  (region_field_s:region(ref),ref5:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 4);
+  ref10 := make_ref(region_field_deref_s:region(int32),4,as_1);
   assume(ref10 > NULL_REF);
   store_to_ref(region_field_s:region(ref),ref5:ref,ref10:ref);
-  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int),ref2:ref + 8);
+  (region_field_next:region(ref),ref4:ref) := gep_ref(region_field_f:region(int32),ref2:ref + 8);
   store_to_ref(region_field_next:region(ref),ref4:ref,ref0:ref);
   i0 = i0+1;
-  (region_field_f:region(int),ref0:ref) := gep_ref(region_field_f:region(int),ref2:ref);
+  (region_field_f:region(int32),ref0:ref) := gep_ref(region_field_f:region(int32),ref2:ref);
   goto bb2_loop;
 bb4:
   assume(-i0 <= -10000);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref0:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref0:ref);
   goto bb6_loop;
 bb6_loop:
   goto bb7,bb8;
@@ -2268,16 +2268,16 @@ bb8:
   assume(ref1 != NULL_REF);
   goto bb9;
 bb9:
-  (region_field_s:region(ref),ref7:ref) := gep_ref(region_field_f:region(int),ref1:ref + 4);
+  (region_field_s:region(ref),ref7:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 4);
   ref6:ref := load_from_ref(region_field_s:region(ref),ref7:ref);
-  b2 = crab_intrinsic(is_unfreed_or_null,region_field_deref_s:region(int),ref6:ref);
-  remove_ref(region_field_deref_s:region(int),ref6:ref);
+  b2 = crab_intrinsic(is_unfreed_or_null,region_field_deref_s:region(int32),ref6:ref);
+  remove_ref(region_field_deref_s:region(int32),ref6:ref);
   goto bb9_assert;
 bb9_assert:
   assert(b2);
-  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int),ref1:ref + 8);
+  (region_field_next:region(ref),ref8:ref) := gep_ref(region_field_f:region(int32),ref1:ref + 8);
   ref9:ref := load_from_ref(region_field_next:region(ref),ref8:ref);
-  (region_field_f:region(int),ref1:ref) := gep_ref(region_field_f:region(int),ref9:ref);
+  (region_field_f:region(int32),ref1:ref) := gep_ref(region_field_f:region(int32),ref9:ref);
   goto bb6_loop;
 
 Invariants using Region
@@ -2291,45 +2291,45 @@ user-defined assertion checker
 === End ./test-bin/region-4 ===
 === Begin ./test-bin/region-5 ===
 entry:
-  region_init(region_0:region(int));
-  region_init(region_1:region(int));
-  region_init(region_2:region(int));
-  i := make_ref(region_0:region(int),4,as_0);
-  x := make_ref(region_1:region(int),4,as_1);
-  y := make_ref(region_2:region(int),4,as_2);
+  region_init(region_0:region(int32));
+  region_init(region_1:region(int32));
+  region_init(region_2:region(int32));
+  i := make_ref(region_0:region(int32),4,as_0);
+  x := make_ref(region_1:region(int32),4,as_1);
+  y := make_ref(region_2:region(int32),4,as_2);
   assume(i != NULL_REF);
   assume(x != NULL_REF);
   assume(y != NULL_REF);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
-  store_to_ref(region_1:region(int),x:ref,1:int32);
-  store_to_ref(region_2:region(int),y:ref,0:int32);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
+  store_to_ref(region_1:region(int32),x:ref,1:int32);
+  store_to_ref(region_2:region(int32),y:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
 bb1_t:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 99);
   goto bb2;
 bb2:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *x = *x+*y;
-  store_to_ref(region_1:region(int),x:ref,*x:int32);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  store_to_ref(region_1:region(int32),x:ref,*x:int32);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *y = *y+1;
-  store_to_ref(region_2:region(int),y:ref,*y:int32);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  store_to_ref(region_2:region(int32),y:ref,*y:int32);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+1;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   goto bb1;
 bb1_f:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -100);
   goto bb3;
 bb3:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   goto ret;
 ret:
   assert(x != NULL_REF);
@@ -2351,48 +2351,48 @@ user-defined assertion checker
 === End ./test-bin/region-5 ===
 === Begin ./test-bin/region-6 ===
 entry:
-  region_init(region_0:region(int));
-  region_init(region_1:region(int));
-  region_init(region_2:region(int));
+  region_init(region_0:region(int32));
+  region_init(region_1:region(int32));
+  region_init(region_2:region(int32));
   z = 100;
-  i := make_ref(region_0:region(int),4,as_0);
-  x := make_ref(region_1:region(int),4,as_1);
-  y := make_ref(region_2:region(int),4,as_2);
+  i := make_ref(region_0:region(int32),4,as_0);
+  x := make_ref(region_1:region(int32),4,as_1);
+  y := make_ref(region_2:region(int32),4,as_2);
   assume(i != NULL_REF);
   assume(x != NULL_REF);
   assume(y != NULL_REF);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
-  store_to_ref(region_1:region(int),x:ref,1:int32);
-  store_to_ref(region_2:region(int),y:ref,0:int32);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
+  store_to_ref(region_1:region(int32),x:ref,1:int32);
+  store_to_ref(region_2:region(int32),y:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
 bb1_t:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 99);
   goto bb2;
 bb2:
   z = z+3;
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *x = *x+*y;
-  store_to_ref(region_1:region(int),x:ref,*x:int32);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  store_to_ref(region_1:region(int32),x:ref,*x:int32);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *y = *y+1;
-  store_to_ref(region_2:region(int),y:ref,*y:int32);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  store_to_ref(region_2:region(int32),y:ref,*y:int32);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+1;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   z = z-3;
   goto bb1;
 bb1_f:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -100);
   goto bb3;
 bb3:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   goto ret;
 ret:
   assert(x != NULL_REF);
@@ -2455,55 +2455,55 @@ Allocation sites for orphan_ptr at the exit: unknown
 === End ./test-bin/region-7 ===
 === Begin ./test-bin/region-8 ===
 entry:
-  region_init(region_0:region(int));
-  region_init(region_1:region(int));
-  region_init(region_2:region(int));
-  i := make_ref(region_0:region(int),4,as_0);
-  x := make_ref(region_1:region(int),4,as_1);
-  y := make_ref(region_2:region(int),4,as_2);
-  crab_intrinsic(add_tag,region_0:region(int),i:ref,1:int32);
-  crab_intrinsic(add_tag,region_1:region(int),x:ref,2:int32);
-  crab_intrinsic(add_tag,region_2:region(int),y:ref,3:int32);
-  store_to_ref(region_0:region(int),i:ref,0:int32);
-  store_to_ref(region_1:region(int),x:ref,1:int32);
-  store_to_ref(region_2:region(int),y:ref,0:int32);
+  region_init(region_0:region(int32));
+  region_init(region_1:region(int32));
+  region_init(region_2:region(int32));
+  i := make_ref(region_0:region(int32),4,as_0);
+  x := make_ref(region_1:region(int32),4,as_1);
+  y := make_ref(region_2:region(int32),4,as_2);
+  crab_intrinsic(add_tag,region_0:region(int32),i:ref,1:int32);
+  crab_intrinsic(add_tag,region_1:region(int32),x:ref,2:int32);
+  crab_intrinsic(add_tag,region_2:region(int32),y:ref,3:int32);
+  store_to_ref(region_0:region(int32),i:ref,0:int32);
+  store_to_ref(region_1:region(int32),x:ref,1:int32);
+  store_to_ref(region_2:region(int32),y:ref,0:int32);
   goto bb1;
 bb1:
   goto bb1_t,bb1_f;
 bb1_t:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(*i <= 99);
   goto bb2;
 bb2:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *x = *x+*y;
-  store_to_ref(region_1:region(int),x:ref,*x:int32);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  store_to_ref(region_1:region(int32),x:ref,*x:int32);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   *y = *y+1;
-  store_to_ref(region_2:region(int),y:ref,*y:int32);
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  store_to_ref(region_2:region(int32),y:ref,*y:int32);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   *i = *i+1;
-  store_to_ref(region_0:region(int),i:ref,*i:int32);
+  store_to_ref(region_0:region(int32),i:ref,*i:int32);
   goto bb1;
 bb1_f:
-  *i:int32 := load_from_ref(region_0:region(int),i:ref);
+  *i:int32 := load_from_ref(region_0:region(int32),i:ref);
   assume(-*i <= -100);
   goto bb3;
 bb3:
-  *x:int32 := load_from_ref(region_1:region(int),x:ref);
-  *y:int32 := load_from_ref(region_2:region(int),y:ref);
+  *x:int32 := load_from_ref(region_1:region(int32),x:ref);
+  *y:int32 := load_from_ref(region_2:region(int32),y:ref);
   goto ret;
 ret:
-  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int),i:ref,2:int32);
+  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int32),i:ref,2:int32);
   assert(b1);
-  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int),i:ref,3:int32);
+  b1 = crab_intrinsic(does_not_have_tag,region_0:region(int32),i:ref,3:int32);
   assert(b1);
-  b1 = crab_intrinsic(does_not_have_tag,region_1:region(int),x:ref,1:int32);
+  b1 = crab_intrinsic(does_not_have_tag,region_1:region(int32),x:ref,1:int32);
   assert(b1);
-  b1 = crab_intrinsic(does_not_have_tag,region_2:region(int),y:ref,1:int32);
+  b1 = crab_intrinsic(does_not_have_tag,region_2:region(int32),y:ref,1:int32);
   assert(b1);
-  b1 = crab_intrinsic(does_not_have_tag,region_1:region(int),x:ref,3:int32);
+  b1 = crab_intrinsic(does_not_have_tag,region_1:region(int32),x:ref,3:int32);
   assert(b1);
 
 
@@ -2859,15 +2859,15 @@ Running top-down inter-procedural analysis with SplitDBM
 0  Number of total unreachable checks
 === End ./test-bin/td_inter_3 ===
 === Begin ./test-bin/td_inter_4 ===
-z:region(int) declare foo(x:int32)
+z:region(int32) declare foo(x:int32)
 entry:
-  region_init(z:region(int));
-  ref := make_ref(z:region(int),4,as_0);
+  region_init(z:region(int32));
+  ref := make_ref(z:region(int32),4,as_0);
   assume(-x+tmp <= 0);
   assume(-tmp < 0);
   goto exit;
 exit:
-  store_to_ref(z:region(int),ref:ref,tmp:int32);
+  store_to_ref(z:region(int32),ref:ref,tmp:int32);
 
 
 void declare main()
@@ -2876,8 +2876,8 @@ entry:
   assume(-x < 0);
   goto exit;
 exit:
-  z:region(int) = call foo(x:int32);
-  lhs:int32 := load_from_ref(z:region(int),ref:ref);
+  z:region(int32) = call foo(x:int32);
+  lhs:int32 := load_from_ref(z:region(int32),ref:ref);
   assert(-x+lhs <= 0);
   assert(-lhs < 0);
 
@@ -2889,15 +2889,15 @@ Running top-down inter-procedural analysis with Region
 0  Number of total unreachable checks
 === End ./test-bin/td_inter_4 ===
 === Begin ./test-bin/td_inter_5 ===
-b:region(int) declare foo(a:int32)
+b:region(int32) declare foo(a:int32)
 entry:
-  region_init(b:region(int));
-  ref := make_ref(b:region(int),4,as_0);
+  region_init(b:region(int32));
+  ref := make_ref(b:region(int32),4,as_0);
   assume(-a+tmp <= 0);
   assume(-tmp < 0);
   goto exit;
 exit:
-  store_to_ref(b:region(int),ref:ref,tmp:int32);
+  store_to_ref(b:region(int32),ref:ref,tmp:int32);
 
 
 void declare main()
@@ -2906,8 +2906,8 @@ entry:
   assume(-x < 0);
   goto exit;
 exit:
-  z:region(int) = call foo(x:int32);
-  lhs:int32 := load_from_ref(z:region(int),ref:ref);
+  z:region(int32) = call foo(x:int32);
+  lhs:int32 := load_from_ref(z:region(int32),ref:ref);
   assert(-x+lhs <= 0);
   assert(-lhs < 0);
 
@@ -4021,9 +4021,9 @@ and
 	{x -> [5, +oo]}
 Unit test 1 for select_ref
 entry:
-  region_init(rgn1:region(int));
-  region_init(rgn2:region(int));
-  region_init(rgn3:region(int));
+  region_init(rgn1:region(int32));
+  region_init(rgn2:region(int32));
+  region_init(rgn3:region(int32));
   assume(ref2 > NULL_REF);
   assume(ref3 > NULL_REF);
   havoc(cond);
@@ -4042,9 +4042,9 @@ user-defined assertion checker
 
 Unit test 2 for select_ref
 entry:
-  region_init(rgn1:region(int));
-  region_init(rgn2:region(int));
-  region_init(rgn3:region(int));
+  region_init(rgn1:region(int32));
+  region_init(rgn2:region(int32));
+  region_init(rgn3:region(int32));
   assume(ref2 > NULL_REF);
   (ref1,rgn1) = ite(cond,(ref2,rgn2),(ref3,rgn3));
   goto exit;
@@ -4061,9 +4061,9 @@ user-defined assertion checker
 
 Unit test 3 for select_ref
 entry:
-  region_init(rgn1:region(int));
-  region_init(rgn2:region(int));
-  region_init(rgn3:region(int));
+  region_init(rgn1:region(int32));
+  region_init(rgn2:region(int32));
+  region_init(rgn3:region(int32));
   assume(ref2 == NULL_REF);
   havoc(cond);
   (ref1,rgn1) = ite(cond,NULL_REF,(ref2,rgn2));
@@ -4081,9 +4081,9 @@ user-defined assertion checker
 
 Unit test 4 for select_ref
 entry:
-  region_init(rgn1:region(int));
-  region_init(rgn2:region(int));
-  region_init(rgn3:region(int));
+  region_init(rgn1:region(int32));
+  region_init(rgn2:region(int32));
+  region_init(rgn3:region(int32));
   assume(ref2 > NULL_REF);
   cond = true;
   (ref1,rgn1) = ite(cond,(ref2,rgn2),(ref3,rgn3));

--- a/tests/inter/td_inter_4.cc
+++ b/tests/inter/td_inter_4.cc
@@ -40,7 +40,7 @@ std::unique_ptr<z_cfg_t> foo(z_var x, z_var z, variable_factory_t &vfac, crab::t
   BB(cfg, entry);
   BB(cfg, exit);
   entry >> exit;
-  z_var ref(vfac["ref"], crab::REF_TYPE, 32);
+  z_var ref(vfac["ref"], crab::REF_TYPE);
   z_var tmp(vfac["tmp"], crab::INT_TYPE, 32);    
   entry.region_init(z);
   z_var_or_cst_t size4(z_number(4), crab::variable_type(crab::INT_TYPE, 32));    
@@ -60,7 +60,7 @@ std::unique_ptr<z_cfg_t> m(z_var x, z_var z, variable_factory_t &vfac, crab::tag
   entry.havoc(x);
   entry.assume(x > 0);
   exit.callsite("foo", {z}, {x});
-  z_var ref(vfac["ref"], crab::REF_TYPE, 32);
+  z_var ref(vfac["ref"], crab::REF_TYPE);
   z_var lhs(vfac["lhs"], crab::INT_TYPE, 32);    
   exit.load_from_ref(lhs, ref, z);
   exit.assertion(z_lin_exp_t(x) >= z_lin_exp_t(lhs));

--- a/tests/inter/td_inter_5.cc
+++ b/tests/inter/td_inter_5.cc
@@ -37,7 +37,7 @@ using namespace crab::cg_impl;
 std::unique_ptr<z_cfg_t> foo(variable_factory_t &vfac, crab::tag_manager &as_man) {
   z_var a(vfac["a"], crab::INT_TYPE, 32);
   z_var b(vfac["b"], crab::REG_INT_TYPE, 32);  
-  z_var ref(vfac["ref"], crab::REF_TYPE, 32);
+  z_var ref(vfac["ref"], crab::REF_TYPE);
   z_var tmp(vfac["tmp"], crab::INT_TYPE, 32);    
   
   function_decl<z_number, varname_t> decl("foo", {a}, {b});
@@ -66,7 +66,7 @@ std::unique_ptr<z_cfg_t> __main(variable_factory_t &vfac, crab::tag_manager &as_
   entry.havoc(x);
   entry.assume(x > 0);
   exit.callsite("foo", {z}, {x});
-  z_var ref(vfac["ref"], crab::REF_TYPE, 32);
+  z_var ref(vfac["ref"], crab::REF_TYPE);
   z_var lhs(vfac["lhs"], crab::INT_TYPE, 32);    
   exit.load_from_ref(lhs, ref, z);
   exit.assertion(z_lin_exp_t(x) >= z_lin_exp_t(lhs));


### PR DESCRIPTION
Integer regions carry a bitwidth; integer arrays do not. That asymmetry is correct — `load_from_ref`/`store_to_ref` have no size operand, so a region's type is the only place its access width can live, while array statements always carry `elem_size` and both array domains derive the element width from it. But nothing enforced it. This branch makes the invariant real and cleans up the surrounding representation.

### `b0a56786` — enforce bitwidth consistency (26 files, +208/−170)

- The type checker now validates that an array access's `elem_size` agrees with the bitwidth of the scalar being loaded or stored, replacing three long-standing TODOs in `arr_init`, `arr_store` and `arr_load`. Bool arrays and non-constant element sizes are excluded. Previously `array_store(a, elem_size=4, i, v:int8)` type-checked and then produced an `int32 := int8` assignment in the base domain — not benign for bitwidth-sensitive domains like `wrapped_interval_domain`.
- `variable_type`'s constructor normalizes `m_bitwidth` away for kinds that don't have one, so a stray width can no longer be stored. Normalizing rather than rejecting keeps existing downstream callers working.
- `get_integer_bitwidth`/`get_integer_region_bitwidth` now `CRAB_ERROR` instead of `assert`, which was compiled out under `-DNDEBUG`.
- Drops 157 redundant width arguments at call sites for kinds with no bitwidth.

The new check caught a real bug in `tests/domains/array_smashing.cc`: eight of ten programs declared `int32` scalars but passed `elem_size=1`, so the smashed ghost was `int8`. Fixed to `4`, matching `prog6`; the test's output is byte-identical to before.

### `404f7d81` — remove the unused array region types (5 files, +4/−66)

`REG_ARR_BOOL_TYPE`, `REG_ARR_INT_TYPE` and `REG_ARR_REAL_TYPE` were never constructed — their only producer was `mk_region`, reachable only via a `store_to_ref` of an array-typed value, which nothing emits. Removes them and the dead handling in `ghost_variables`, `region_cast`, the `ERROR_IF_ARRAY_REGION` guard, and the printers. Array types themselves are untouched; only regions *containing* an array are gone.

### `f660b4d4` — print the bitwidth of integer regions (3 files, +220/−247)

`variable_type::write` printed `region(int)` while `type_value::write` printed `region(int32)` for the same type. Makes `variable_type::write` the single definition and has `type_value::write` delegate, dropping a 27-line near-duplicate. `UNK_TYPE` now prints `untyped` and the switch is exhaustive.

### Testing

`ctest` 118/118, and `run_tests.sh` green for all six configurations. Only `expected_results.out` changed — 241 occurrences of `region(int)` → `region(int32)`, a one-to-one substitution with nothing else in the diff. `elina` was verified statically rather than by running (its binaries bus-error on macOS but compile); its expected output contains no region types.

### Downstream note

Two source-compatible-but-not-binary-compatible changes: removing the three enum values renumbers `UNK_TYPE` from 15 to 12, so clients need a rebuild rather than a relink. I checked clam18 — it never references the removed types or predicates, and its region mapping has no array case. seahorn and other consumers are unverified. Also, the new `elem_size` check is a hard `CRAB_ERROR`; any client CFG with the same mismatch will now abort where it previously ran. Downgrading it to `CRAB_WARN` for one release is a reasonable option if you'd rather give clam runway.
